### PR TITLE
Add source-map-compactor back in, again

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "semver": "^5.5.0",
     "simple-random": "^1.0.3",
     "source-map": "^0.7.3",
+    "source-map-compactor": "^1.0.1",
     "tslib": "^1.9.3",
     "typescript": "^3.0.1",
     "update-notifier": "^2.5.0",

--- a/src/__snapshots__/compile.test.ts.snap
+++ b/src/__snapshots__/compile.test.ts.snap
@@ -148,7 +148,7 @@ return t}console.log(r(\\"hello\\"))
 exports[`when compiling a module with statements above an import declaration builds 1`] = `
 "\\"use strict\\"
 require(\\"util\\")
-var e=require(\\"cbor\\")
+foo()
 console.log(\\"Hello!\\")
 "
 `;

--- a/src/__test__/compile/statementsBeforeImport.js
+++ b/src/__test__/compile/statementsBeforeImport.js
@@ -1,3 +1,3 @@
-const cbor = require('cbor');
+foo();
 import 'util';
 console.log('Hello!');

--- a/src/types/source-map-compactor/index.d.ts
+++ b/src/types/source-map-compactor/index.d.ts
@@ -1,0 +1,3 @@
+declare function sourceMapCompactor(map: { toString(): string }): string;
+declare namespace sourceMapCompactor { }
+export = sourceMapCompactor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,6 +4251,13 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+source-map-compactor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/source-map-compactor/-/source-map-compactor-1.0.1.tgz#94372d27d1fca2d8f0ebf7ddbd210c783c3494fc"
+  integrity sha1-lDctJ9H8otjw6/fdvSEMeDw0lPw=
+  dependencies:
+    source-map "^0.5.6"
+
 source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"


### PR DESCRIPTION
The soure maps Rollup produces are broken. The source-map-compactor
package fixes them. We regress on the exact same issue every time we try
to take it out. Let's stop trying to take it out; it never ends well.