### PR TITLE
Add Node version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
     "ignore": [
       "gulp-zip"
     ]
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
Node 8 is our minimum supported version I believe, so let's enforce that.