### PR TITLE
Run tests on the oldest Node version we support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - "8.0.0"
+  - "10.0.0"
 
 os:
   - linux
   - osx
 
 dist: trusty
-sudo: false
 
 cache: yarn
 


### PR DESCRIPTION
Also migrate to the VM-based infrastructure.
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures