### PR TITLE
Don't mutate native component ELF data in-place

### DIFF
--- a/src/nativeComponents.ts
+++ b/src/nativeComponents.ts
@@ -59,7 +59,6 @@ function readMetadata(elfPath: string) {
 
   const buildIDData = findSection('buildid');
   checkBufferLength(buildIDData, 8, 'Build ID');
-  buildIDData.swap64();
 
   const appIDData = findSection('appuuid');
   checkBufferLength(appIDData, 16, 'App UUID');
@@ -90,7 +89,7 @@ function readMetadata(elfPath: string) {
     path: elfPath,
     data: elfData,
     appID: formatUUID(appIDData),
-    buildID: `0x${buildIDData.toString('hex')}`,
+    buildID: `0x${Buffer.from(buildIDData).swap64().toString('hex')}`,
     family: findSection('appfamily').toString(),
   };
 }


### PR DESCRIPTION
The native component binary is loaded into memory to read the metadata,
then the raw binary data is passed along with the parsed metadata to
avoid having to read it a second time. `buf.swap64()` mutates the
buffer in-place, so we were unintentionally mutating the component
binary when reading the buildID. Byte-swap a copy of the buffer so that
the component binary is left untouched.