### PR TITLE
Annotate BuildError and PluginError with diagnostic target

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "drop-stream": "^1.0.0",
     "elfy": "^0.1.0",
     "error-subclass": "^2.2.0",
+    "events-intercept": "^2.0.0",
     "fs-extra": "^7.0.0",
     "glob": "^7.1.3",
     "gulp-file": "^0.4.0",

--- a/src/types/events-intercept/index.d.ts
+++ b/src/types/events-intercept/index.d.ts
@@ -1,0 +1,10 @@
+import { EventEmitter } from 'events';
+
+export function patch(emitter: EventEmitter): void;
+
+export interface InterceptedEventEmitter extends EventEmitter {
+  intercept(
+    event: string,
+    cb: (arg: any, done: (err: Error | null, returnVal: any) => void) => void,
+  ): void;
+}

--- a/src/util/BuildError.test.ts
+++ b/src/util/BuildError.test.ts
@@ -1,4 +1,5 @@
 import BuildError from './BuildError';
+import { DiagnosticTarget } from '../diagnostics';
 
 describe('is()', () => {
   it('returns false if error is not a BuildError', () =>
@@ -14,4 +15,10 @@ describe('toDiagnostic()', () => {
   it('returns an error diagnostic', () =>
     expect(new BuildError('uh oh!').toDiagnostic()).toMatchSnapshot(),
   );
+
+  it('returns an error diagnostic with a target set', () => {
+    const err = new BuildError('uh oh!');
+    err.target = DiagnosticTarget.Companion;
+    expect(err.toDiagnostic()).toMatchSnapshot();
+  });
 });

--- a/src/util/BuildError.ts
+++ b/src/util/BuildError.ts
@@ -1,6 +1,10 @@
 import ErrorSubclass from 'error-subclass';
 
-import { Diagnostic, DiagnosticCategory, DiagnosticTarget } from '../diagnostics';
+import {
+  Diagnostic,
+  DiagnosticCategory,
+  DiagnosticTarget,
+} from '../diagnostics';
 
 export default class BuildError extends ErrorSubclass {
   static displayName = 'BuildError';

--- a/src/util/BuildError.ts
+++ b/src/util/BuildError.ts
@@ -1,9 +1,11 @@
 import ErrorSubclass from 'error-subclass';
 
-import { Diagnostic, DiagnosticCategory } from '../diagnostics';
+import { Diagnostic, DiagnosticCategory, DiagnosticTarget } from '../diagnostics';
 
 export default class BuildError extends ErrorSubclass {
   static displayName = 'BuildError';
+
+  target?: DiagnosticTarget;
 
   static is(error: Error): error is BuildError {
     return error instanceof BuildError;
@@ -13,6 +15,7 @@ export default class BuildError extends ErrorSubclass {
     return {
       category: DiagnosticCategory.Error,
       messageText: this.message,
+      ...(this.target && { target: this.target }),
     };
   }
 }

--- a/src/util/__snapshots__/BuildError.test.ts.snap
+++ b/src/util/__snapshots__/BuildError.test.ts.snap
@@ -6,3 +6,11 @@ Object {
   "messageText": "uh oh!",
 }
 `;
+
+exports[`toDiagnostic() returns an error diagnostic with a target set 1`] = `
+Object {
+  "category": 1,
+  "messageText": "uh oh!",
+  "target": "companion",
+}
+`;

--- a/src/util/eventsIntercept.ts
+++ b/src/util/eventsIntercept.ts
@@ -1,0 +1,8 @@
+import { EventEmitter } from 'events';
+
+import { InterceptedEventEmitter, patch } from 'events-intercept';
+
+export default function eventsIntercept<T extends EventEmitter>(obj: T) {
+  patch(obj);
+  return obj as T & InterceptedEventEmitter;
+}

--- a/src/util/pluginError.ts
+++ b/src/util/pluginError.ts
@@ -48,7 +48,8 @@ const ignoredPluginErrorProps = new Set([
 ]);
 
 function hasDiagnosticTarget<T extends PluginError>(err: T):
-  err is T & { target: DiagnosticTarget } {
+  err is T & { target: DiagnosticTarget }
+{
   return Object.values(DiagnosticTarget).indexOf((err as any).target) !== -1;
 }
 

--- a/src/util/pluginError.ts
+++ b/src/util/pluginError.ts
@@ -1,7 +1,7 @@
 import indentString from 'indent-string';
 import PluginError from 'plugin-error';
 
-import { Diagnostic, DiagnosticCategory } from '../diagnostics';
+import { Diagnostic, DiagnosticCategory, DiagnosticTarget } from '../diagnostics';
 
 export function isPluginError(value: unknown): value is PluginError {
   // We can't just do an instanceof check as the error object might be
@@ -44,7 +44,13 @@ const ignoredPluginErrorProps = new Set([
   'showProperties',
   'showStack',
   'stack',
+  'target',
 ]);
+
+function hasDiagnosticTarget<T extends PluginError>(err: T):
+  err is T & { target: DiagnosticTarget } {
+  return Object.values(DiagnosticTarget).indexOf((err as any).target) !== -1;
+}
 
 function convertToDiagnostic(
   error: PluginError<{ columnNumber?: number }>,
@@ -53,6 +59,10 @@ function convertToDiagnostic(
     category: DiagnosticCategory.Error,
     messageText: `${error.name}: ${error.message}`,
   };
+
+  if (hasDiagnosticTarget(error)) {
+    diagnostic.target = error.target;
+  }
 
   // Our own spin on PluginError.prototype._messageDetails().
   if (error.showProperties) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,11 @@ event-stream@^4.0.1:
     stream-combiner "^0.2.2"
     through "^2.3.8"
 
+events-intercept@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/events-intercept/-/events-intercept-2.0.0.tgz#adbf38681c5a4b2011c41ee41f61a34cba448897"
+  integrity sha1-rb84aBxaSyARxB7kH2GjTLpEiJc=
+
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"


### PR DESCRIPTION
Currently, errors thrown are attributed to no component and show simply as "build" in the diagnostic output, which is confusing for developers. This change annotates those errors with the appropriate target so developers can determine where their error was (in cases where it isn't obvious based on any referenced path).