### PR TITLE
Enable SonarTS lint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rm -rf lib && tsc -p tsconfig.build.json",
     "test": "jest",
-    "lint": "tsc --noEmit --noUnusedLocals && tslint --project .",
+    "lint": "tsc --noEmit --noUnusedLocals && tslint --project . --format codeFrame",
     "depcheck": "depcheck --ignores='@types/*,tslint-config-airbnb' --ignore-dirs='toolchain,__test__'",
     "checkstyle": "prettier --list-different '**/*.{js,jsx,ts,tsx,json}'",
     "prepublishOnly": "npm run test && npm run build"
@@ -56,7 +56,8 @@
     "ts-jest": "^23.0.0",
     "tslint": "^5.11.0",
     "tslint-config-airbnb": "^5.9.2",
-    "tslint-config-prettier": "^1.16.0"
+    "tslint-config-prettier": "^1.16.0",
+    "tslint-sonarts": "^1.8.0"
   },
   "dependencies": {
     "@babel/core": "^7.1.2",

--- a/src/appPackageManifest.ts
+++ b/src/appPackageManifest.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { Transform } from 'stream';
+import { Transform, TransformCallback } from 'stream';
 
 import * as t from 'io-ts';
 import { failure } from 'io-ts/lib/PathReporter';
@@ -44,6 +44,133 @@ const ComponentBundleTag = t.taggedUnion('type', [
 ]);
 type ComponentBundleTag = t.TypeOf<typeof ComponentBundleTag>;
 
+function getBundleInfo(file: Vinyl) {
+  return ComponentBundleTag.decode(file.componentBundle).getOrElseL(
+    (errors) => {
+      throw new PluginError(
+        PLUGIN_NAME,
+        `Unknown bundle component tag: ${failure(errors).join('\n')}`,
+        { fileName: file.relative },
+      );
+    },
+  );
+}
+
+class AppPackageManifestTransform extends Transform {
+  sourceMaps = {};
+  components: Components = {};
+  hasJS = false;
+  hasNative = false;
+
+  constructor(
+    public projectConfig: ProjectConfiguration,
+    public buildID: string,
+  ) {
+    super({ objectMode: true });
+  }
+
+  private transformComponentBundle(file: Vinyl) {
+    const bundleInfo = getBundleInfo(file);
+
+    function throwDuplicateComponent(existingPath: string) {
+      const componentType =
+        bundleInfo.type === 'device'
+          ? `${bundleInfo.type}/${bundleInfo.family}`
+          : bundleInfo.type;
+      throw new PluginError(
+        PLUGIN_NAME,
+        `Duplicate ${componentType} component bundles: ${
+          file.relative
+        } / ${existingPath}`,
+      );
+    }
+
+    if (bundleInfo.type === 'device') {
+      if (bundleInfo.isNative) this.hasNative = true;
+      else this.hasJS = true;
+
+      if (this.hasJS && this.hasNative) {
+        throw new PluginError(
+          PLUGIN_NAME,
+          'Cannot bundle mixed native/JS device components',
+          { fileName: file.relative },
+        );
+      }
+
+      if (!this.components.watch) this.components.watch = {};
+
+      if (this.components.watch[bundleInfo.family]) {
+        throwDuplicateComponent(
+          this.components.watch[bundleInfo.family].filename,
+        );
+      }
+
+      this.components.watch[bundleInfo.family] = {
+        platform: bundleInfo.platform,
+        filename: file.relative,
+      };
+    } else {
+      if (this.components[bundleInfo.type] !== undefined) {
+        throwDuplicateComponent(this.components[bundleInfo.type]!.filename);
+      }
+
+      this.components[bundleInfo.type] = { filename: file.relative };
+    }
+  }
+
+  // tslint:disable-next-line:function-name
+  _transform(file: Vinyl, _: unknown, next: TransformCallback) {
+    if (file.componentMapKey) {
+      lodash.merge(
+        this.sourceMaps,
+        lodash.set({}, file.componentMapKey, normalizeToPOSIX(file.relative)),
+      );
+    }
+
+    if (file.componentBundle) {
+      try {
+        this.transformComponentBundle(file);
+      } catch (ex) {
+        return next(ex);
+      }
+    }
+
+    return next(undefined, file);
+  }
+
+  // tslint:disable-next-line:function-name
+  _flush(callback: TransformCallback) {
+    const setSDKVersion =
+      (this.components.watch && this.hasJS) || this.components.companion;
+    const { deviceApi, companionApi } = apiVersions(this.projectConfig);
+    const manifestJSON = JSON.stringify(
+      {
+        buildId: this.buildID,
+        components: this.components,
+        sourceMaps: this.sourceMaps,
+        manifestVersion: 6,
+        ...(setSDKVersion && {
+          sdkVersion: {
+            ...(this.components.watch && this.hasJS && { deviceApi }),
+            ...(this.components.companion && { companionApi }),
+          },
+        }),
+        requestedPermissions: this.projectConfig.requestedPermissions,
+        appId: this.projectConfig.appUUID,
+      },
+      undefined,
+      2,
+    );
+    this.push(
+      new Vinyl({
+        contents: Buffer.from(manifestJSON, 'utf8'),
+        path: path.resolve(process.cwd(), manifestPath),
+      }),
+    );
+    callback();
+  }
+}
+
 export default function appPackageManifest({
   projectConfig,
   buildId,
@@ -51,120 +178,5 @@ export default function appPackageManifest({
   projectConfig: ProjectConfiguration;
   buildId: string;
 }) {
-  const sourceMaps = {};
-  const components: Components = {};
-  let hasJS = false;
-  let hasNative = false;
-
-  const stream = new Transform({
-    objectMode: true,
-    transform(file: Vinyl, _, next) {
-      if (file.componentMapKey) {
-        lodash.merge(
-          sourceMaps,
-          lodash.set({}, file.componentMapKey, normalizeToPOSIX(file.relative)),
-        );
-      }
-
-      if (file.componentBundle) {
-        let bundleInfo: ComponentBundleTag;
-        try {
-          bundleInfo = ComponentBundleTag.decode(
-            file.componentBundle,
-          ).getOrElseL((errors) => {
-            throw new Error(
-              `Unknown bundle component tag: ${failure(errors).join('\n')}`,
-            );
-          });
-        } catch (ex) {
-          return next(
-            new PluginError(PLUGIN_NAME, ex, { fileName: file.relative }),
-          );
-        }
-
-        function throwDuplicateComponent(existingPath: string) {
-          const componentType =
-            bundleInfo.type === 'device'
-              ? `${bundleInfo.type}/${bundleInfo.family}`
-              : bundleInfo.type;
-          next(
-            new PluginError(
-              PLUGIN_NAME,
-              `Duplicate ${componentType} component bundles: ${
-                file.relative
-              } / ${existingPath}`,
-            ),
-          );
-        }
-
-        if (bundleInfo.type === 'device') {
-          if (bundleInfo.isNative) hasNative = true;
-          else hasJS = true;
-
-          if (hasJS && hasNative) {
-            return next(
-              new PluginError(
-                PLUGIN_NAME,
-                'Cannot bundle mixed native/JS device components',
-                { fileName: file.relative },
-              ),
-            );
-          }
-
-          if (!components.watch) components.watch = {};
-
-          if (components.watch[bundleInfo.family]) {
-            return throwDuplicateComponent(
-              components.watch[bundleInfo.family].filename,
-            );
-          }
-
-          components.watch[bundleInfo.family] = {
-            platform: bundleInfo.platform,
-            filename: file.relative,
-          };
-        } else {
-          if (components[bundleInfo.type] !== undefined) {
-            return throwDuplicateComponent(
-              components[bundleInfo.type]!.filename,
-            );
-          }
-
-          components[bundleInfo.type] = { filename: file.relative };
-        }
-      }
-      next(undefined, file);
-    },
-    flush(callback) {
-      const setSDKVersion = (components.watch && hasJS) || components.companion;
-      const { deviceApi, companionApi } = apiVersions(projectConfig);
-      const manifestJSON = JSON.stringify(
-        {
-          buildId,
-          components,
-          sourceMaps,
-          manifestVersion: 6,
-          ...(setSDKVersion && {
-            sdkVersion: {
-              ...(components.watch && hasJS && { deviceApi }),
-              ...(components.companion && { companionApi }),
-            },
-          }),
-          requestedPermissions: projectConfig.requestedPermissions,
-          appId: projectConfig.appUUID,
-        },
-        undefined,
-        2,
-      );
-      stream.push(
-        new Vinyl({
-          contents: Buffer.from(manifestJSON, 'utf8'),
-          path: path.resolve(process.cwd(), manifestPath),
-        }),
-      );
-      callback();
-    },
-  });
-
-  return stream;
+  return new AppPackageManifestTransform(projectConfig, buildId);
 }

--- a/src/convertImageToTXI.ts
+++ b/src/convertImageToTXI.ts
@@ -92,7 +92,7 @@ function transformPNGStream(
 export default function convertImageToTXI(
   options: ConvertImageToTXIOptions = {},
 ) {
-  const stream = new Transform({
+  return new Transform({
     objectMode: true,
     transform(this: Transform, file: Vinyl, _, cb) {
       if (file.isNull() || file.extname !== '.png') {
@@ -120,6 +120,4 @@ export default function convertImageToTXI(
       }
     },
   });
-
-  return stream;
 }

--- a/src/gulpMagicString.ts
+++ b/src/gulpMagicString.ts
@@ -24,7 +24,7 @@ async function mergeSourceMaps(inMap: RawSourceMap, outMap: RawSourceMap) {
 export default function gulpMagicString(
   transformerFunc: (code: string, magicString: MagicString) => void,
 ) {
-  const transform = new Transform({
+  return new Transform({
     objectMode: true,
     transform(file: Vinyl, _, next) {
       if (file.isNull() || file.extname !== '.js') {
@@ -73,6 +73,4 @@ export default function gulpMagicString(
       }
     },
   });
-
-  return transform;
 }

--- a/src/gulpSetProperty.ts
+++ b/src/gulpSetProperty.ts
@@ -3,13 +3,11 @@ import { Transform } from 'stream';
 import Vinyl from 'vinyl';
 
 export default function gulpSetProperty(properties: {}) {
-  const transform = new Transform({
+  return new Transform({
     objectMode: true,
     transform(file: Vinyl, _, next) {
       if (!file.isNull()) Object.assign(file, properties);
       next(undefined, file);
     },
   });
-
-  return transform;
 }

--- a/src/nativeComponents.ts
+++ b/src/nativeComponents.ts
@@ -114,29 +114,33 @@ export default function nativeComponents(
     (c) => c.appID.toLowerCase() !== appID.toLowerCase(),
   );
   if (divergentAppIDComponents.length > 0) {
+    const divergentAppIDsList = divergentAppIDComponents
+      .map(
+        ({ path, family, appID }) => `${path} (${family}) has appID ${appID}`,
+      )
+      .join('\n    ');
+
     throw new PluginError(
       PLUGIN_NAME,
       `App IDs of native components do not match package.json.
     Expected appID ${appID}.
-    ${divergentAppIDComponents
-      .map(
-        ({ path, family, appID }) => `${path} (${family}) has appID ${appID}`,
-      )
-      .join('\n  ')}`,
+    ${divergentAppIDsList}`,
     );
   }
 
   // Check that all build IDs of native components match
   if (lodash.uniqBy(components, (c) => c.buildID).length > 1) {
-    throw new PluginError(
-      PLUGIN_NAME,
-      `Build IDs of native components do not match.
-    ${components
+    const mismatchedBuildIDs = components
       .map(
         ({ path, family, buildID }) =>
           `${path} (${family}) has buildID ${buildID}`,
       )
-      .join('\n  ')}`,
+      .join('\n    ');
+
+    throw new PluginError(
+      PLUGIN_NAME,
+      `Build IDs of native components do not match.
+    ${mismatchedBuildIDs}`,
     );
   }
 

--- a/src/plugins/typescript/index.ts
+++ b/src/plugins/typescript/index.ts
@@ -1,5 +1,5 @@
 import { Plugin } from 'rollup';
-import { createFilter } from 'rollup-pluginutils';
+import { createFilter, Filter } from 'rollup-pluginutils';
 import ts from 'typescript';
 
 import LanguageServiceHost from './LanguageServiceHost';
@@ -10,8 +10,8 @@ import { default as tslib } from './tslib.const';
 import { Diagnostic } from '../../diagnostics';
 
 interface IOptions {
-  include: string | string[] | RegExp | RegExp[];
-  exclude: string | string[] | RegExp | RegExp[];
+  include: Filter;
+  exclude: Filter;
   tsconfig?: string;
   tsconfigOverride?: ts.CompilerOptions;
   onDiagnostic: (diagnostic: Diagnostic) => void;
@@ -26,7 +26,7 @@ const generateMessage = (tsDiagnostic: ts.Diagnostic) => {
   if (typeof tsDiagnostic.messageText === 'string') {
     return formatTSDiagMessage({
       code: tsDiagnostic.code,
-      messageText: tsDiagnostic.messageText as string,
+      messageText: tsDiagnostic.messageText,
     });
   }
   const messages = [];

--- a/src/validateIcon.ts
+++ b/src/validateIcon.ts
@@ -46,7 +46,7 @@ export default function validateIcon({
 
   let iconExists = false;
 
-  const validateStream = new stream.Transform({
+  return new stream.Transform({
     objectMode: true,
     transform(this: stream.Transform, file: Vinyl, _, cb) {
       if (
@@ -103,6 +103,4 @@ export default function validateIcon({
       cb();
     },
   });
-
-  return validateStream;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["tslint-config-airbnb", "tslint-config-prettier"],
+  "extends": [
+    "tslint-config-airbnb",
+    "tslint-config-prettier",
+    "tslint-sonarts"
+  ],
   "rules": {
     "no-inferrable-types": true,
     "prefer-template": [true, "allow-single-concat"],
@@ -13,7 +17,9 @@
         "vinyl": "Vinyl",
         "vinylFs": "vinylFS"
       }
-    ]
+    ],
+    "no-duplicate-string": false,
+    "no-identical-functions": false
   },
   "linterOptions": {
     "exclude": ["src/**/__test__"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,6 +2259,11 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+immutable@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -5139,6 +5144,13 @@ tslint-microsoft-contrib@~5.2.0:
   resolved "https://registry.yarnpkg.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz#a6286839f800e2591d041ea2800c77487844ad81"
   dependencies:
     tsutils "^2.27.2 <2.29.0"
+
+tslint-sonarts@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/tslint-sonarts/-/tslint-sonarts-1.8.0.tgz#80f2e8addd418c3b8807fc0155dec33b5a81e8d1"
+  integrity sha512-tpijO5VR18e+Ny99uMNNov3Hw7diiYQ8KoJkezpHGw9hSFFrO5g2PhwdQQo7O9puhJKMIutLl9g+ICMgg+bh0w==
+  dependencies:
+    immutable "^3.8.2"
 
 tslint@^5.11.0:
   version "5.11.0"


### PR DESCRIPTION
Fix or suppress the lint issues it uncovered. The 'no-duplicate-string'
and 'no-duplicate-functions' rules were too noisy for test code so they
were disabled.

The appPackageManifest transform function had too much cognitive
complexity for the linter. Refactor it into smaller, more manageable
pieces.