### PR TITLE
Convert toolchain version to SDK version

### DIFF
--- a/src/sdkVersion.test.ts
+++ b/src/sdkVersion.test.ts
@@ -1,3 +1,4 @@
+import { SemVer, satisfies } from 'semver';
 import sdkVersion, { apiVersions } from './sdkVersion';
 
 it('throws if package version has no known mapping', () => {
@@ -47,5 +48,27 @@ it('is able to map the current SDK version to API versions', () => {
   expect(apiVersions()).toEqual({
     deviceApi: expect.any(String),
     companionApi: expect.any(String),
+  });
+});
+
+describe('given a specific toolchain version', () => {
+  let version: SemVer;
+
+  beforeEach(() => {
+    version = sdkVersion('3.0.5-pre.7');
+  });
+
+  it('converts the toolchain version to an SDK version', () => {
+    expect(version).toMatchObject({
+      major: 3,
+      minor: 0,
+      patch: 0,
+      prerelease: [],
+      version: '3.0.0',
+    });
+  });
+
+  it('returns an SDK version that compares as expected', () => {
+    expect(satisfies(version, '>=3.0.0')).toBe(true);
   });
 });

--- a/src/sdkVersion.ts
+++ b/src/sdkVersion.ts
@@ -7,6 +7,10 @@ export default function sdkVersion(toolchainVersion = packageVersionConst) {
   if (version === null) {
     throw new Error(`Invalid SDK package version: ${toolchainVersion}`);
   }
+  // SDK versions do not have a patch or prerelease. Strip them out.
+  version.patch = 0;
+  version.prerelease = [];
+  version.format(); // Side effect: updates the version.version property.
   return version;
 }
 


### PR DESCRIPTION
The toolchain version is a function of the SDK version it targets, but
they are not equivalent. Derive the SDK version from the toolchain
version by stripping off the patch and prerelease fields so that semver
range comparisons with SDK version work as intended.

This fixes the bug where the access_exercise permission is
unintentionally disallowed in toolchain v3.0.0-pre.x versions.