### PR TITLE
Workaround Android issue that can't tolerate entry point in dir

### DIFF
--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -42,16 +42,20 @@ function compileFile(
   {
     allowUnknownExternals = undefined as boolean | undefined,
     component = ComponentType.COMPANION,
+    outputDir = undefined as string | undefined,
   } = {},
+  expectFilename?: string,
 ) {
   return getFileFromStream(
     compile({
       component,
       allowUnknownExternals,
+      outputDir,
       entryPoint: testResourcePath(filename),
       onDiagnostic: mockDiagnosticHandler,
       defaultLanguage: 'en-US',
     }),
+    expectFilename,
   );
 }
 
@@ -68,6 +72,15 @@ it.each([
     compileFile(filename).then(getVinylContents),
   ).resolves.toMatchSnapshot(),
 );
+
+it('emits files in a specified output directory', () =>
+  expect(
+    compileFile(
+      'basic.js',
+      { outputDir: 'some_directory' },
+      'some_directory/basic.js',
+    ),
+  ).resolves.toBeDefined());
 
 // Just check build is successful
 it.each([['importing a package', 'importPackage.js']])(

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -46,12 +46,14 @@ function pluginIf(condition: boolean, plugin: () => rollup.Plugin) {
 export default function compile({
   component,
   entryPoint,
+  outputDir,
   defaultLanguage,
   allowUnknownExternals = false,
   onDiagnostic = logDiagnosticToConsole,
 }: {
   component: ComponentType;
   entryPoint: string;
+  outputDir?: string;
   defaultLanguage: string;
   allowUnknownExternals?: boolean;
   onDiagnostic?: DiagnosticHandler;
@@ -61,7 +63,6 @@ export default function compile({
   const { translationsGlob } = componentTargets[component];
   return new pumpify.obj([
     rollupToVinyl(
-      component,
       {
         input: entryPoint,
         external: externals[component],
@@ -114,6 +115,8 @@ export default function compile({
         inlineDynamicImports: true,
       },
       {
+        dir: outputDir,
+        file: outputDir === undefined ? `${component}.js` : undefined,
         format: 'cjs',
         sourcemap: true,
       },

--- a/src/componentTargets.ts
+++ b/src/componentTargets.ts
@@ -1,5 +1,6 @@
 interface ComponentTarget {
   inputs: string[];
+  outputDir?: string;
   notFoundIsFatal: boolean;
   translationsGlob: string;
 }
@@ -13,6 +14,7 @@ export enum ComponentType {
 const componentTarget: { [component in ComponentType]: ComponentTarget } = {
   [ComponentType.DEVICE]: {
     inputs: ['app/index.ts', 'app/index.js'],
+    outputDir: 'app',
     notFoundIsFatal: true,
     translationsGlob: 'app/i18n/*.po',
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export function buildComponent({
   component: ComponentType;
   onDiagnostic?: DiagnosticHandler;
 }) {
-  const { inputs, notFoundIsFatal } = componentTargets[component];
+  const { inputs, outputDir, notFoundIsFatal } = componentTargets[component];
 
   const entryPoint = findEntryPoint(inputs, {
     onDiagnostic,
@@ -148,6 +148,7 @@ export function buildComponent({
           component,
           onDiagnostic,
           entryPoint,
+          outputDir,
           allowUnknownExternals: projectConfig.enableProposedAPI,
           defaultLanguage: projectConfig.defaultLanguage,
         }),

--- a/src/testUtils/getFileFromStream.ts
+++ b/src/testUtils/getFileFromStream.ts
@@ -8,7 +8,7 @@ export default function getFileFromStream(
 ) {
   return new Promise<Vinyl>((resolve, reject) => {
     stream.on('data', (file: Vinyl) => {
-      if (file.contents && (!filename || file.basename === filename)) {
+      if (file.contents && (!filename || file.relative === filename)) {
         resolve(file);
       }
     });


### PR DESCRIPTION
The Android app can't deal with companion/settings entry points being within a directory, so the previous Rollup 1.0 changes prevent sideloading newly built apps. This change limits that behaviour to the device bundle, which can tolerate this. We can drop this change once the minimum SDK target in the repo maps to a new enough SDK version that contains the fix.