### PR TITLE
Configure terser to emit code compatible with iOS 10

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -123,6 +123,8 @@ export default function compile({
     ),
     gulpTerser({
       ecma,
+      // We still support iOS 10, which ships Safari 10
+      safari10: component !== ComponentType.DEVICE,
       mangle: {
         toplevel: true,
       },

--- a/src/types/terser/index.d.ts
+++ b/src/types/terser/index.d.ts
@@ -11,10 +11,12 @@ interface OutputOptions {
 }
 
 export interface TerserOptions {
+  // tslint:disable-next-line max-union-size
   ecma?: 5 | 6 | 7 | 8;
   compress?: CompressOptions | false;
   mangle?: MangleOptions | false;
   output?: OutputOptions;
+  safari10?: boolean;
 }
 
 interface TerserResult {}


### PR DESCRIPTION
We still support iOS 10 which ships Safari 10 which has known bugs that Terser can workaround. Let's enable those workarounds.