### PR TITLE
Update and pin io-ts to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "humanize-list": "^1.0.1",
     "indent-string": "^3.2.0",
     "inquirer": "^6.0.0",
-    "io-ts": "^1.3.1",
+    "io-ts": "1.7.0",
     "lazystream": "^1.0.0",
     "lodash": "^4.17.10",
     "magic-string": "^0.25.0",

--- a/src/__snapshots__/appPackageManifest.test.ts.snap
+++ b/src/__snapshots__/appPackageManifest.test.ts.snap
@@ -143,13 +143,13 @@ Object {
 }
 `;
 
-exports[`emits an error if a component bundle tag has a device type but invalid platform 1`] = `"Unknown bundle component tag: Invalid value \\"1.1.1+\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>)/platform: Array<string>"`;
+exports[`emits an error if a component bundle tag has a device type but invalid platform 1`] = `"Unknown bundle component tag: Invalid value \\"1.1.1+\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
 
-exports[`emits an error if a component bundle tag has a device type but missing family 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>)/family: string"`;
+exports[`emits an error if a component bundle tag has a device type but missing family 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/family: string"`;
 
-exports[`emits an error if a component bundle tag has a device type but missing platform 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>)/platform: Array<string>"`;
+exports[`emits an error if a component bundle tag has a device type but missing platform 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
 
-exports[`emits an error if a component bundle tag has an invalid type field 1`] = `"Unknown bundle component tag: Invalid value \\"__invalid__\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & PartialType<{ isNative: true }>) | { type: \\"companion\\" })/type: \\"device\\" | \\"companion\\""`;
+exports[`emits an error if a component bundle tag has an invalid type field 1`] = `"Unknown bundle component tag: Invalid value \\"__invalid__\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/type: \\"device\\" | \\"companion\\""`;
 
 exports[`emits an error if both JS and native device components are present 1`] = `"Cannot bundle mixed native/JS device components"`;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,9 +2363,10 @@ invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
 
-io-ts@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.3.1.tgz#04b71579fec0592cb758bd460a1fc0520f18b3c8"
+io-ts@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-1.7.0.tgz#7e291b058afdde72f30d54e12e10761bfd8edd7a"
+  integrity sha512-NFXDhjUNW+JKzNIkSeHTUUMXn+2QVoPg33qTIcoS7eDycupoeeeMqgmqlT7EiIe4n5w31Dc1uUrhg7Rt0Kf7xA==
   dependencies:
     fp-ts "^1.0.0"
 


### PR DESCRIPTION
io-ts often breaks our tests when it updates because they change the format of errors. Pinned it to avoid the noise from Greenkeeper yelling things are broken. We'll still get notified when an update is available.