### PR TITLE
Normalize entry point paths in manifests to POSIX style paths

### DIFF
--- a/src/componentManifest.ts
+++ b/src/componentManifest.ts
@@ -105,7 +105,7 @@ export function makeDeviceManifest({
               ),
             );
           }
-          entryPoint = file.relative;
+          entryPoint = normalizeToPOSIX(file.relative);
         } else {
           return next(
             new PluginError(
@@ -198,7 +198,7 @@ export function makeCompanionManifest({
               ),
             );
           }
-          companionEntryPoint = file.relative;
+          companionEntryPoint = normalizeToPOSIX(file.relative);
         } else if (file.componentType === ComponentType.SETTINGS) {
           if (settingsEntryPoint) {
             return next(
@@ -208,7 +208,7 @@ export function makeCompanionManifest({
               ),
             );
           }
-          settingsEntryPoint = file.relative;
+          settingsEntryPoint = normalizeToPOSIX(file.relative);
         } else {
           return next(
             new PluginError(


### PR DESCRIPTION
Manifests should always contain POSIX style paths, but we accidentally used the `file.relative` of entrypoints without normalizing it to POSIX. This meant the manifest was invalid when building on Windows.