### PR TITLE
Fixing the user-activity polyfill/wrapper (take #2)

### DIFF
--- a/src/buildTargets.ts
+++ b/src/buildTargets.ts
@@ -36,10 +36,9 @@ const baseBuildTargets: { [platform: string]: BuildTargetDescriptor } = {
       orientation:
         'export var OrientationSensor = undefined; export default OrientationSensor;',
       'user-activity': `
-        export * from "user-activity";
-        export { default } from "user-activity";
-        import { today } from "user-activity";
-        Object.defineProperty(today.local, "elevationGain", {});
+        export { today, goals, default } from 'user-activity';
+        import { today } from 'user-activity';
+        Object.defineProperty(today.local, 'elevationGain', {});
       `,
     },
   },


### PR DESCRIPTION
Getting this right is hard. Turns out the previous version broke `import * as userActivity from 'user-activity';` because https://github.com/rollup/rollup/issues/2165.