### PR TITLE
Allow implicit any

### DIFF
--- a/sdk-tsconfig.json
+++ b/sdk-tsconfig.json
@@ -12,7 +12,7 @@
     "allowJs": true,
     "jsx": "react",
     "jsxFactory": "createComponent",
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noEmitOnError": true,
     "downlevelIteration": true,
     "sourceMap": true,


### PR DESCRIPTION
`noImplicitAny: true` with a `checkJS: true` (see [fitbit-sdk-types apply command](https://github.com/SergioMorchon/fitbit-sdk-types/blob/9ed502e56e6e7db59135da5dfc883a115c79c41c/scripts/apply.js#L41)) implies that the developer must add JSDoc types to all function arguments, variables etc.
That adds an unneeded overhead to newcomers that only wanted to add autocomplete and that kind of stuff.
I could _override_ it in the fitbit-sdk-types script, but as this is the source package, maybe we should let the developer to choose the strictness level they want on their project, leaving the default as the less strict one.