### PR TITLE
Update settings scaffolding

### DIFF
--- a/scaffold/settings/index.jsx
+++ b/scaffold/settings/index.jsx
@@ -1,15 +1,16 @@
-function settingsComponent(props) {
-  return (
-    <Page>
-      <Section
-        title={
-          <Text bold align="center">
-            App Settings
-          </Text>
-        }
-      />
-    </Page>
-  );
-}
-
-registerSettingsPage(settingsComponent);
+registerSettingsPage(({ settings }) => (
+  <Page>
+    <Section
+      title={
+        <Text bold align="center">
+          App Settings
+        </Text>
+      }
+    >
+      <Text>
+        This is a very basic demo settings page to show off some of the current
+        capabilities of the Companion Settings library.
+      </Text>
+    </Section>
+  </Page>
+));


### PR DESCRIPTION
When applying the types to the settings/index.jsx file, I found some small issues agains the documentation:

1. The `Section` component looks makes no sense without a content (`children`), so I've added the same example shown in the reference.
1. The component, although named in lowerCamelCase, creats a function that is called only once, and also has no documentation about the input. Because TypeScript only infers types if it is called directly from a documented function, I moved it right inside the `registerSettingsPage` so it will detect automatically the prop types of the callback.

Signed-off-by: Sergio Morchón Poveda <sergio.morchon@outlook.com>