### PR TITLE
Don't polyfill i18n in SDK 4.2 and beyond

### DIFF
--- a/src/__snapshots__/compile.test.ts.snap
+++ b/src/__snapshots__/compile.test.ts.snap
@@ -201,12 +201,19 @@ Array [
 ]
 `;
 
-exports[`when building a device component which uses gettext polyfills gettext on device 1`] = `
+exports[`when building a device component which uses the gettext polyfill polyfills gettext on device 1`] = `
 "\\"use strict\\"
 var e=require(\\"resources\\")
 function r(r){var t=e.getResource(\\"text\\",\\"_\\"+r)
 if(t===null)return String(r)
 return t}console.log(r(\\"hello\\"))
+"
+`;
+
+exports[`when building a device component which uses the i18n API without requiring a polyfill does not polyfill gettext on device 1`] = `
+"\\"use strict\\"
+var e=require(\\"i18n\\")
+console.log(e.gettext(\\"hello\\"))
 "
 `;
 

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -23,7 +23,7 @@ const mockSDKVersion = sdkVersion as jest.Mock;
 
 beforeEach(() => {
   mockDiagnosticHandler = jest.fn();
-  mockSDKVersion.mockReturnValue({ major: 4, minor: 0 });
+  mockSDKVersion.mockReturnValue({ major: 4, minor: 1 });
 
   // We don't want to load the actual tsconfig.json for this project
   // during unit tests. Using a real tsconfig.json located within
@@ -194,17 +194,33 @@ describe('when allowUnknownExternals is enabled', () => {
   });
 });
 
-describe('when building a device component which uses gettext', () => {
+describe('when building a device component which uses the gettext polyfill', () => {
   let file: string;
 
   beforeEach(async () => {
-    mockSDKVersion.mockReturnValue({ major: 3, minor: 1 });
     file = await compileFile('i18n.js', {
       component: ComponentType.DEVICE,
     }).then(getVinylContents);
   });
 
   it('polyfills gettext on device', () => expect(file).toMatchSnapshot());
+
+  it('builds without diagnostic messages', () =>
+    expect(mockDiagnosticHandler).not.toBeCalled());
+});
+
+describe('when building a device component which uses the i18n API without requiring a polyfill', () => {
+  let file: string;
+
+  beforeEach(async () => {
+    mockSDKVersion.mockReturnValue({ major: 4, minor: 2 });
+    file = await compileFile('i18n.js', {
+      component: ComponentType.DEVICE,
+    }).then(getVinylContents);
+  });
+
+  it('does not polyfill gettext on device', () =>
+    expect(file).toMatchSnapshot());
 
   it('builds without diagnostic messages', () =>
     expect(mockDiagnosticHandler).not.toBeCalled());

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -13,7 +13,6 @@ import {
   logDiagnosticToConsole,
 } from './diagnostics';
 import rollupToVinyl from './rollupToVinyl';
-import sdkVersion from './sdkVersion';
 
 import forbidAbsoluteImport from './plugins/forbidAbsoluteImport';
 import i18nPolyfill from './plugins/i18nPolyfill';
@@ -100,7 +99,7 @@ export default function compile({
           }),
         ),
         // Must come before terser in order not to wrap strict directive
-        ...pluginIf(sdkVersion().major >= 4, workaroundRequireScope),
+        workaroundRequireScope(),
         terser({
           ecma,
           // We still support iOS 10, which ships Safari 10
@@ -127,8 +126,7 @@ export default function compile({
           : undefined,
       }),
       // Companion/Settings have no FS and therefore can't use code splitting
-      inlineDynamicImports:
-        sdkVersion().major < 4 || component !== ComponentType.DEVICE,
+      inlineDynamicImports: component !== ComponentType.DEVICE,
     },
     {
       dir: outputDir,

--- a/src/plugins/platformExternals.ts
+++ b/src/plugins/platformExternals.ts
@@ -29,6 +29,7 @@ const device = [
   'gyroscope',
   'haptics',
   'heart-rate',
+  'i18n',
   'jpeg',
   'orientation',
   'power',


### PR DESCRIPTION
I also cleaned up some SDK back-compat code that only applied to SDK 4.0 and backwards, which we no longer support.