### PR TITLE
Fix for tsconfig false error about override soure files

### DIFF
--- a/sdk-tsconfig.json
+++ b/sdk-tsconfig.json
@@ -4,7 +4,7 @@
     "noEmitHelpers": false,
     "importHelpers": true,
     "noResolve": false,
-    "noEmit": false,
+    "noEmit": true,
     "inlineSourceMap": false,
     "moduleResolution": "node",
     "target": "es5",


### PR DESCRIPTION
Fix for tsconfig false error about override soure files, like:
> Cannot write file 'some-file.js' because it would overwrite input file.

That's because the root `sdk-tsconfig.json` file has a `noEmit: false`, that implies that TypeScript will emit a file with the same name.
But on the other hand, that specific compiler flag is overriden by the [`compile`](https://github.com/Fitbit/fitbit-sdk-toolchain/blob/master/src/compile.ts#L34) script

So it should be safe to declare it here as `noEmit: true`