### PR TITLE
Write supported screen sizes into the app manifest at build

### DIFF
--- a/src/__snapshots__/appPackageManifest.test.ts.snap
+++ b/src/__snapshots__/appPackageManifest.test.ts.snap
@@ -143,6 +143,52 @@ Object {
 }
 `;
 
+exports[`builds a package manifest with supported capabilities 1`] = `
+Object {
+  "appId": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
+  "buildId": "0x0f75775f470c1585",
+  "components": Object {
+    "watch": Object {
+      "higgs": Object {
+        "filename": "device-higgs.zip",
+        "platform": Array [
+          "30.1.2+",
+        ],
+        "supports": Object {
+          "screenSize": Object {
+            "h": 250,
+            "w": 348,
+          },
+        },
+      },
+      "meson": Object {
+        "filename": "device-meson.zip",
+        "platform": Array [
+          "32.4.18+",
+        ],
+        "supports": Object {
+          "screenSize": Object {
+            "h": 300,
+            "w": 300,
+          },
+        },
+      },
+    },
+  },
+  "manifestVersion": 6,
+  "requestedPermissions": Array [],
+  "sdkVersion": Object {
+    "deviceApi": "*",
+  },
+  "sourceMaps": Object {
+    "device": Object {
+      "higgs": "sourceMaps/device/higgs/index.js.json",
+      "meson": "sourceMaps/device/meson/index.js.json",
+    },
+  },
+}
+`;
+
 exports[`emits an error if a component bundle tag has a device type but invalid platform 1`] = `"Unknown bundle component tag: Invalid value \\"1.1.1+\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
 
 exports[`emits an error if a component bundle tag has a device type but missing family 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/family: string"`;
@@ -153,4 +199,6 @@ exports[`emits an error if a component bundle tag has an invalid type field 1`] 
 
 exports[`emits an error if both JS and native device components are present 1`] = `"Cannot bundle mixed native/JS device components"`;
 
-exports[`emits an error if multiple bundles are present for the same device family 1`] = `"Duplicate device/foo component bundles: bundle1.zip / bundle0.zip"`;
+exports[`emits an error if multiple companion bundles are present for the same device family 1`] = `"Duplicate companion component bundles: bundle1.zip / bundle0.zip"`;
+
+exports[`emits an error if multiple device bundles are present for the same device family 1`] = `"Duplicate device/foo component bundles: bundle1.zip / bundle0.zip"`;

--- a/src/__snapshots__/componentManifest.test.ts.snap
+++ b/src/__snapshots__/componentManifest.test.ts.snap
@@ -158,6 +158,36 @@ Object {
 
 exports[`when there is a device entry point present builds a device manifest for an app 1`] = `
 Object {
+  "apiVersion": "*",
+  "appManifestVersion": 1,
+  "appType": "clockface",
+  "buildId": "0x0f75775f470c1585",
+  "bundleDate": "2018-06-27T00:00:00.000Z",
+  "i18n": Object {
+    "en-us": Object {
+      "name": "My App",
+    },
+    "fr-fr": Object {
+      "name": "Mon application",
+    },
+  },
+  "main": "device/index.js",
+  "name": "My App",
+  "requestedPermissions": Array [],
+  "supports": Object {
+    "screenSize": Object {
+      "h": 300,
+      "w": 300,
+    },
+  },
+  "svgMain": "resources/index.gui",
+  "svgWidgets": "resources/widgets.gui",
+  "uuid": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
+}
+`;
+
+exports[`when there is a device entry point present builds a device manifest for an app 2`] = `
+Object {
   "apiVersion": "5.0.0",
   "appManifestVersion": 1,
   "appType": "app",

--- a/src/__snapshots__/sdkVersion.test.ts.snap
+++ b/src/__snapshots__/sdkVersion.test.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`throws if package version has no known mapping 1`] = `"No known API versions for SDK package version 1000.0"`;
+
+exports[`throws if package version is invalid 1`] = `"Invalid SDK package version: .."`;

--- a/src/appPackageManifest.ts
+++ b/src/appPackageManifest.ts
@@ -9,6 +9,7 @@ import lodash from 'lodash';
 import PluginError from 'plugin-error';
 import Vinyl from 'vinyl';
 
+import { SupportedDeviceCapabilities } from './capabilities';
 import { normalizeToPOSIX } from './pathUtils';
 import ProjectConfiguration from './ProjectConfiguration';
 import { apiVersions } from './sdkVersion';
@@ -21,6 +22,7 @@ interface Components {
     [platform: string]: {
       filename: string;
       platform: string[];
+      supports?: SupportedDeviceCapabilities;
     };
   };
   companion?: {
@@ -109,9 +111,16 @@ class AppPackageManifestTransform extends Transform {
         );
       }
 
+      const { deviceApi } = apiVersions(this.projectConfig);
+      const supports = SupportedDeviceCapabilities.create(
+        deviceApi,
+        bundleInfo.family,
+      );
+
       this.components.watch[bundleInfo.family] = {
         platform: bundleInfo.platform,
         filename: file.relative,
+        ...(this.hasJS && supports && { supports }),
       };
     } else {
       if (this.components[bundleInfo.type] !== undefined) {

--- a/src/buildTargets.test.ts
+++ b/src/buildTargets.test.ts
@@ -12,6 +12,7 @@ jest.mock(
       },
       bar: {
         displayName: 'Bar',
+        specs: { screenSize: { width: 300, height: 300 } },
       },
       baz: {
         displayName: 'Baz',
@@ -35,6 +36,7 @@ it('merges the build target descriptors', () => {
       displayName: 'Fitbit Ionic',
       platform: expect.any(Array),
       resourceFilterTag: '348x250',
+      specs: { screenSize: { width: 348, height: 250 } },
     },
     // Unfortunately, due to the way that module mocking works, the
     // extra build targets constant cannot be deduped easily.
@@ -43,6 +45,7 @@ it('merges the build target descriptors', () => {
     },
     bar: {
       displayName: 'Bar',
+      specs: { screenSize: { width: 300, height: 300 } },
     },
   });
 });

--- a/src/buildTargets.ts
+++ b/src/buildTargets.ts
@@ -7,6 +7,12 @@ export interface BuildTargetDescriptor {
   displayName: string;
   platform: string[];
   resourceFilterTag: string;
+  specs: {
+    screenSize: {
+      width: number;
+      height: number;
+    };
+  };
   maxDeviceBundleSize?: number; // in bytes
   minSDKVersion?: string;
 }
@@ -16,24 +22,28 @@ const baseBuildTargets: { [platform: string]: BuildTargetDescriptor } = {
     displayName: 'Fitbit Ionic',
     platform: ['30.1.2+'],
     resourceFilterTag: '348x250',
+    specs: { screenSize: { width: 348, height: 250 } },
   },
   meson: {
     displayName: 'Fitbit Versa',
     platform: ['32.4.18+'],
     resourceFilterTag: '300x300',
+    specs: { screenSize: { width: 300, height: 300 } },
   },
   gemini: {
     displayName: 'Fitbit Versa Lite',
     platform: ['33.1.30+'],
     resourceFilterTag: '300x300',
+    specs: { screenSize: { width: 300, height: 300 } },
     minSDKVersion: '3.1.0',
     maxDeviceBundleSize: 3145728,
   },
   mira: {
     displayName: 'Fitbit Versa 2',
     platform: ['68.9.12+'],
-    minSDKVersion: '4.0.0',
     resourceFilterTag: '300x300',
+    specs: { screenSize: { width: 300, height: 300 } },
+    minSDKVersion: '4.0.0',
   },
 };
 

--- a/src/capabilities.test.ts
+++ b/src/capabilities.test.ts
@@ -1,0 +1,49 @@
+import semver from 'semver';
+
+import { SupportedDeviceCapabilities } from './capabilities';
+
+describe('SupportedDeviceCapabilities', () => {
+  describe('create()', () => {
+    it('returns supported capabilities for * as JS API version', () => {
+      expect(SupportedDeviceCapabilities.create('*', 'mira')).toEqual(
+        expect.objectContaining({
+          screenSize: { w: 300, h: 300 },
+        }),
+      );
+    });
+
+    it('returns supported capabilities for JS API versions greater than the threshold version', () => {
+      expect(
+        SupportedDeviceCapabilities.create(
+          SupportedDeviceCapabilities.presentSince,
+          'higgs',
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          screenSize: { w: 348, h: 250 },
+        }),
+      );
+    });
+
+    it('does not return any supported capabilities for JS API versions lower than the threshold version', () => {
+      const illegibleVersion = () => {
+        const presentSince = semver.parse(
+          SupportedDeviceCapabilities.presentSince,
+        );
+        if (!presentSince) throw new Error('Failed to parse version.');
+        presentSince.major -= 1;
+        return presentSince.format();
+      };
+
+      expect(
+        SupportedDeviceCapabilities.create(illegibleVersion(), 'higgs'),
+      ).toBeUndefined();
+    });
+
+    it('throws an error if the target JS API version string is not valid', () => {
+      expect(() =>
+        SupportedDeviceCapabilities.create('..', 'mira'),
+      ).toThrowError();
+    });
+  });
+});

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,70 @@
+import semver from 'semver';
+
+import buildTargets from './buildTargets';
+
+/**
+ * Names for known device capabilities.
+ */
+export enum DeviceCapability {
+  SCREEN_SIZE = 'screenSize',
+}
+
+/**
+ * Structure describing the supported device capabilities, as included in the app manifest.
+ */
+export interface SupportedDeviceCapabilities {
+  /** Array of screen sizes supported by the application. */
+  [DeviceCapability.SCREEN_SIZE]: { w: number; h: number };
+}
+
+export namespace SupportedDeviceCapabilities {
+  /**
+   * Device capabilities supported by the application being built will not be
+   * included into the manifest when targeting a JS API version lower than this.
+   */
+  export const presentSince = '7.0.0';
+
+  /**
+   * Creates and populates an object describing the supported device capabilities.
+   * @param targetJsApiVersion The JS API version required by the application.
+   * @param targetDevice Device family name.
+   *
+   * If the target JS API version is lower than `7.0.0`, then we will not include
+   * the supported device capabilities into the app manifest to avoid introducing
+   * any issues when parsed on device. This function signals this case by
+   * returning `undefined` instead of an instance of `SupportedDeviceCapabilities`.
+   *
+   * @returns an instance of `SupportedDeviceCapabilities` or `undefined`
+   */
+  export function create(
+    targetJsApiVersion: string,
+    targetDevice: string,
+  ): SupportedDeviceCapabilities | undefined {
+    let isVersionEligibleForCaps = false;
+
+    if (targetJsApiVersion === '*') {
+      isVersionEligibleForCaps = true;
+    } else {
+      const parsedDeviceApi = semver.parse(targetJsApiVersion);
+
+      if (!parsedDeviceApi) {
+        throw new Error(`Failed to parse version "${targetJsApiVersion}".`);
+      }
+
+      isVersionEligibleForCaps = semver.gte(parsedDeviceApi, presentSince);
+    }
+
+    if (isVersionEligibleForCaps) {
+      const { screenSize } = buildTargets[targetDevice].specs;
+
+      return {
+        [DeviceCapability.SCREEN_SIZE]: {
+          w: screenSize.width,
+          h: screenSize.height,
+        },
+      };
+    }
+
+    return undefined;
+  }
+}

--- a/src/componentManifest.test.ts
+++ b/src/componentManifest.test.ts
@@ -65,6 +65,7 @@ function makeDeviceManifestStream(
     makeDeviceManifest({
       buildId,
       projectConfig,
+      targetDevice: 'mira',
     }),
   );
 }
@@ -135,6 +136,16 @@ describe('when there is a device entry point present', () => {
 
   it('builds a device manifest for a clock', () =>
     expectManifestJSON(makeDeviceManifestStream()).resolves.toMatchSnapshot());
+
+  it('includes supported screen sizes for a clock', () => {
+    const projectConfig = {
+      ...makeClockfaceProjectConfig(),
+      enableProposedAPI: true,
+    } as ProjectConfiguration;
+    expectManifestJSON(
+      makeDeviceManifestStream(projectConfig),
+    ).resolves.toMatchSnapshot();
+  });
 
   it('builds a device manifest for an app', () =>
     expectManifestJSON(

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,7 @@ export function buildDeviceComponents({
               compileTranslations(projectConfig.defaultLanguage),
             ),
           ),
-          makeDeviceManifest({ projectConfig, buildId }),
+          makeDeviceManifest({ projectConfig, buildId, targetDevice: family }),
           zip(bundleFilename),
           transformIf(
             maxDeviceBundleSize !== undefined,

--- a/src/sdkVersion.test.ts
+++ b/src/sdkVersion.test.ts
@@ -5,6 +5,10 @@ it('throws if package version has no known mapping', () => {
   expect(() => apiVersions({}, '1000.0.0')).toThrowErrorMatchingSnapshot();
 });
 
+it('throws if package version is invalid', () => {
+  expect(() => apiVersions({}, '..')).toThrowErrorMatchingSnapshot();
+});
+
 it('provides a mapping for SDKv4.0', () => {
   expect(apiVersions({}, '4.0.0')).toEqual({
     deviceApi: '5.0.0',


### PR DESCRIPTION
When building an application, include the capabilities supported by the application into the application and device manifests.

- Added screen sizes to all build targets.
- Added a new `supports` field to both manifests, containing the required capabilities as key-value pairs.
- Defined a new capability, `screenSize`, that specifies the screen size supported by the app being built, determined from the targeted device family.

Example:
```
  "supports": {
    "screenSize": {
      "w": 300,
      "h": 300
    }
  },
```

Signed-off-by: Claudiu Nedelcu <cnedelcu@fitbit.com>
