### PR TITLE
Use module namespace as default export for built-in modules without default exports

### DIFF
--- a/src/__snapshots__/compile.test.ts.snap
+++ b/src/__snapshots__/compile.test.ts.snap
@@ -172,6 +172,14 @@ Array [
 ]
 `;
 
+exports[`when building a device component which uses a module without default exports patches generated code to use the module namespace as the default export 1`] = `
+"\\"use strict\\"
+var e=require(\\"crypto\\"),o=require(\\"document\\"),t=require(\\"fs\\"),f=require(\\"jpeg\\"),l=require(\\"power\\"),r=require(\\"scientific\\"),s=require(\\"scientific/signal\\"),u=require(\\"system\\"),i=require(\\"user-activity\\"),p=require(\\"user-settings\\")
+function y(e){return e&&e.__esModule?e:{default:e}}var c=y(e),n=y(o),a=y(t),g=y(f),d=y(l),q=y(r),m=y(s),v=y(u),j=y(i),w=y(p)
+console.log(\\"typeof crypto: \\"+typeof c.default),console.log(\\"typeof document: \\"+typeof n.default),console.log(\\"typeof fs: \\"+typeof a.default),console.log(\\"typeof jpeg: \\"+typeof g.default),console.log(\\"typeof power: \\"+typeof d.default),console.log(\\"typeof scientific: \\"+typeof q.default),console.log(\\"typeof signal: \\"+typeof m.default),console.log(\\"typeof system: \\"+typeof v.default),console.log(\\"typeof userActivity: \\"+typeof j.default),console.log(\\"typeof userSettings: \\"+typeof w.default)
+"
+`;
+
 exports[`when building a device component which uses the gettext polyfill polyfills gettext on device 1`] = `
 "\\"use strict\\"
 var e,l=require(\\"resources\\")

--- a/src/__test__/compile/noDefaultExport.js
+++ b/src/__test__/compile/noDefaultExport.js
@@ -1,0 +1,21 @@
+import crypto from 'crypto';
+import document from 'document';
+import fs from 'fs';
+import jpeg from 'jpeg';
+import power from 'power';
+import scientific from 'scientific';
+import signal from 'scientific/signal';
+import system from 'system';
+import userActivity from 'user-activity';
+import userSettings from 'user-settings';
+
+console.log('typeof crypto: ' + typeof crypto);
+console.log('typeof document: ' + typeof document);
+console.log('typeof fs: ' + typeof fs);
+console.log('typeof jpeg: ' + typeof jpeg);
+console.log('typeof power: ' + typeof power);
+console.log('typeof scientific: ' + typeof scientific);
+console.log('typeof signal: ' + typeof signal);
+console.log('typeof system: ' + typeof system);
+console.log('typeof userActivity: ' + typeof userActivity);
+console.log('typeof userSettings: ' + typeof userSettings);

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -249,3 +249,19 @@ it('emits multiple chunks when dynamic import are used', async () => {
   expect(entryJS).toMatchSnapshot();
   expect(chunkJS).toMatchSnapshot();
 });
+
+describe('when building a device component which uses a module without default exports', () => {
+  let file: string;
+
+  beforeEach(async () => {
+    file = await compileFile('noDefaultExport.js', {
+      component: ComponentType.DEVICE,
+    }).then(getVinylContents);
+  });
+
+  it('patches generated code to use the module namespace as the default export', () =>
+    expect(file).toMatchSnapshot());
+
+  it('builds without diagnostic messages', () =>
+    expect(mockDiagnosticHandler).not.toBeCalled());
+});


### PR DESCRIPTION
Several built-in modules do not have a default export. This PR configures Rollup to use the module namespace as the default export for these modules.