### PR TITLE
Allow configuring companion default wake interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fitbit/sdk",
-  "version": "5.0.0-pre.6",
+  "version": "5.0.0-pre.7",
   "description": "Toolchain for building Fitbit apps",
   "author": "Fitbit, Inc.",
   "license": "BSD-3-Clause",

--- a/src/ProjectConfiguration.test.ts
+++ b/src/ProjectConfiguration.test.ts
@@ -286,6 +286,7 @@ it('validationErrors() validates all fields', () => {
       'fr-FR': { name: '' },
     },
     defaultLanguage: '_invalid_',
+    companionDefaultWakeInterval: '_invalid_',
   };
   expect(config.validate(configFile).diagnostics).toEqual([
     expect.objectContaining({
@@ -325,6 +326,11 @@ it('validationErrors() validates all fields', () => {
       category: DiagnosticCategory.Error,
       messageText:
         'Default language is an invalid language tag: _invalid_. Must be en-US, de-DE, es-ES, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, sv-SE, zh-CN, zh-TW, pt-BR, id-ID, ro-RO, ru-RU, pl-PL or cs-CZ.',
+    }),
+    expect.objectContaining({
+      category: DiagnosticCategory.Error,
+      messageText:
+        'Default companion wake interval must be an integer value greater than or equal to 300000',
     }),
     expect.objectContaining({
       category: DiagnosticCategory.Error,

--- a/src/ProjectConfiguration.ts
+++ b/src/ProjectConfiguration.ts
@@ -19,6 +19,8 @@ export const VALID_APP_TYPES = Object.values(AppType);
 
 export const MAX_LENGTH_APP_CLUSTER_ID = 64;
 
+const MIN_COMPANION_DEFAULT_WAKE_INTERVAL_MS = 300000;
+
 export type LocalesConfig = { [locale: string]: { name: string } };
 
 export interface BaseProjectConfiguration {
@@ -34,6 +36,7 @@ export interface BaseProjectConfiguration {
   enableProposedAPI?: true;
   appClusterID?: string;
   developerID?: string;
+  companionDefaultWakeInterval?: number;
 }
 
 export interface AppProjectConfiguration extends BaseProjectConfiguration {
@@ -547,6 +550,25 @@ export function validateStorageGroup(config: ProjectConfiguration) {
   return diagnostics;
 }
 
+export function validateCompanionDefaultWakeInterval(
+  config: ProjectConfiguration,
+) {
+  const diagnostics = new DiagnosticList();
+
+  if (
+    typeof config.companionDefaultWakeInterval !== 'undefined' &&
+    (!Number.isInteger(config.companionDefaultWakeInterval) ||
+      config.companionDefaultWakeInterval <
+        MIN_COMPANION_DEFAULT_WAKE_INTERVAL_MS)
+  ) {
+    diagnostics.pushFatalError(
+      `Default companion wake interval must be an integer value greater than or equal to ${MIN_COMPANION_DEFAULT_WAKE_INTERVAL_MS}`,
+    );
+  }
+
+  return diagnostics;
+}
+
 interface ValidationOptions {
   hasNativeComponents?: boolean;
 }
@@ -571,6 +593,7 @@ export function validate(
     validateLocaleDisplayNames,
     validateDefaultLanguage,
     validateStorageGroup,
+    validateCompanionDefaultWakeInterval,
   ].forEach((validator) => diagnostics.extend(validator(config)));
   diagnostics.extend(validateBuildTarget(config, { hasNativeComponents }));
   return diagnostics;

--- a/src/__snapshots__/componentManifest.test.ts.snap
+++ b/src/__snapshots__/componentManifest.test.ts.snap
@@ -114,6 +114,22 @@ Object {
 }
 `;
 
+exports[`when there is a companion entry point present sets default companion wake interval if configured 1`] = `
+Object {
+  "apiVersion": "3.1.0",
+  "buildId": "0x0f75775f470c1585",
+  "bundleDate": "2018-06-27T00:00:00.000Z",
+  "companion": Object {
+    "main": "companion/index.js",
+  },
+  "defaultWakeInterval": 300000,
+  "manifestVersion": 2,
+  "name": "My App",
+  "requestedPermissions": Array [],
+  "uuid": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
+}
+`;
+
 exports[`when there is a companion entry point present when there is a settings entry point present builds a companion manifest with settings 1`] = `
 Object {
   "apiVersion": "3.1.0",

--- a/src/componentManifest.test.ts
+++ b/src/componentManifest.test.ts
@@ -286,6 +286,14 @@ describe('when there is a companion entry point present', () => {
       }),
     ).resolves.toMatchSnapshot());
 
+  it('sets default companion wake interval if configured', () =>
+    expectManifestJSON(
+      makeCompanionManifestStream(false, {
+        ...makeClockfaceProjectConfig(),
+        companionDefaultWakeInterval: 300000,
+      }),
+    ).resolves.toMatchSnapshot());
+
   it('emits an error if project has settings but no settings entry point', () =>
     expectManifestJSON(
       makeCompanionManifestStream(true),

--- a/src/componentManifest.ts
+++ b/src/componentManifest.ts
@@ -174,6 +174,7 @@ interface CompanionManifest extends ComponentManifest {
   };
   appClusters?: string[];
   developerProfileId?: string;
+  defaultWakeInterval?: number;
 }
 
 function makeCommonManifest({
@@ -391,6 +392,11 @@ export function makeCompanionManifest({
 
       if (projectConfig.developerID) {
         manifest.developerProfileId = projectConfig.developerID;
+      }
+
+      if (projectConfig.companionDefaultWakeInterval) {
+        manifest.defaultWakeInterval =
+          projectConfig.companionDefaultWakeInterval;
       }
 
       done(


### PR DESCRIPTION
Added option to configure default wake interval for companions. Represented by the `defaultWakeInterval` field in the companion manifest, populated from the value of the `companionDefaultWakeInterval` field in project configuration.

Signed-off-by: Claudiu Nedelcu <cnedelcu@fitbit.com>