### PR TITLE
Remove interop hack for SDK 6.0

### DIFF
--- a/src/__mocks__/packageVersion.const.ts
+++ b/src/__mocks__/packageVersion.const.ts
@@ -1,1 +1,1 @@
-export default '5.0.0';
+export default '6.0.0';

--- a/src/__snapshots__/appPackageManifest.test.ts.snap
+++ b/src/__snapshots__/appPackageManifest.test.ts.snap
@@ -23,7 +23,7 @@ Object {
   "manifestVersion": 6,
   "requestedPermissions": Array [],
   "sdkVersion": Object {
-    "deviceApi": "7.0.0",
+    "deviceApi": "8.1.0",
   },
   "sourceMaps": Object {
     "device": Object {
@@ -59,8 +59,8 @@ Object {
   "manifestVersion": 6,
   "requestedPermissions": Array [],
   "sdkVersion": Object {
-    "companionApi": "3.1.0",
-    "deviceApi": "7.0.0",
+    "companionApi": "3.3.0",
+    "deviceApi": "8.1.0",
   },
   "sourceMaps": Object {
     "companion": "sourceMaps/companion/companion.js.json",
@@ -112,7 +112,7 @@ Object {
   "manifestVersion": 6,
   "requestedPermissions": Array [],
   "sdkVersion": Object {
-    "companionApi": "3.1.0",
+    "companionApi": "3.3.0",
   },
   "sourceMaps": Object {
     "companion": "sourceMaps/companion/companion.js.json",
@@ -156,7 +156,7 @@ Object {
   "manifestVersion": 6,
   "requestedPermissions": Array [],
   "sdkVersion": Object {
-    "deviceApi": "7.0.0",
+    "deviceApi": "8.1.0",
   },
   "sourceMaps": Object {
     "device": Object {

--- a/src/__snapshots__/compile.test.ts.snap
+++ b/src/__snapshots__/compile.test.ts.snap
@@ -182,7 +182,7 @@ Array [
 ]
 `;
 
-exports[`when building a device component which uses a module without default exports patches generated code to use the module namespace as the default export 1`] = `
+exports[`when building a device component which uses a module without default exports on SDK 5.0 patches generated code to use the module namespace as the default export 1`] = `
 "\\"use strict\\"
 var e=require(\\"crypto\\"),o=require(\\"document\\"),t=require(\\"fs\\"),f=require(\\"jpeg\\"),l=require(\\"power\\"),r=require(\\"scientific\\"),s=require(\\"scientific/signal\\"),u=require(\\"system\\"),i=require(\\"user-activity\\"),p=require(\\"user-settings\\")
 function y(e){return e&&e.__esModule?e:{default:e}}var c=y(e),n=y(o),a=y(t),g=y(f),d=y(l),q=y(r),m=y(s),v=y(u),j=y(i),w=y(p)

--- a/src/__snapshots__/componentManifest.test.ts.snap
+++ b/src/__snapshots__/componentManifest.test.ts.snap
@@ -74,7 +74,7 @@ PluginError {
 
 exports[`when there is a companion entry point present builds a companion manifest 1`] = `
 Object {
-  "apiVersion": "3.1.0",
+  "apiVersion": "3.3.0",
   "buildId": "0x0f75775f470c1585",
   "bundleDate": "2018-06-27T00:00:00.000Z",
   "companion": Object {
@@ -97,7 +97,7 @@ PluginError {
 
 exports[`when there is a companion entry point present sets app cluster storage related fields if configured 1`] = `
 Object {
-  "apiVersion": "3.1.0",
+  "apiVersion": "3.3.0",
   "appClusters": Array [
     "a.storage.group",
   ],
@@ -116,7 +116,7 @@ Object {
 
 exports[`when there is a companion entry point present sets default companion wake interval if configured 1`] = `
 Object {
-  "apiVersion": "3.1.0",
+  "apiVersion": "3.3.0",
   "buildId": "0x0f75775f470c1585",
   "bundleDate": "2018-06-27T00:00:00.000Z",
   "companion": Object {
@@ -132,7 +132,7 @@ Object {
 
 exports[`when there is a companion entry point present when there is a settings entry point present builds a companion manifest with settings 1`] = `
 Object {
-  "apiVersion": "3.1.0",
+  "apiVersion": "3.3.0",
   "buildId": "0x0f75775f470c1585",
   "bundleDate": "2018-06-27T00:00:00.000Z",
   "companion": Object {
@@ -150,7 +150,7 @@ Object {
 
 exports[`when there is a device entry point present builds a device manifest for a clock 1`] = `
 Object {
-  "apiVersion": "7.0.0",
+  "apiVersion": "8.1.0",
   "appManifestVersion": 1,
   "appType": "clockface",
   "buildId": "0x0f75775f470c1585",
@@ -180,7 +180,7 @@ Object {
 
 exports[`when there is a device entry point present builds a device manifest for a service 1`] = `
 Object {
-  "apiVersion": "7.0.0",
+  "apiVersion": "8.1.0",
   "appManifestVersion": 1,
   "appType": "service",
   "buildId": "0x0f75775f470c1585",
@@ -238,7 +238,7 @@ Object {
 
 exports[`when there is a device entry point present builds a device manifest for an app 2`] = `
 Object {
-  "apiVersion": "7.0.0",
+  "apiVersion": "8.1.0",
   "appManifestVersion": 1,
   "appType": "app",
   "buildId": "0x0f75775f470c1585",
@@ -268,13 +268,13 @@ Object {
 }
 `;
 
-exports[`when there is a device entry point present when there are compiled language files ensures the default language en-US is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"},\\"es-es\\":{\\"resources\\":\\"spanish/language\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"7.0.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":336,\\"h\\":336}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
+exports[`when there is a device entry point present when there are compiled language files ensures the default language en-US is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"},\\"es-es\\":{\\"resources\\":\\"spanish/language\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"8.1.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":336,\\"h\\":336}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
 
-exports[`when there is a device entry point present when there are compiled language files ensures the default language es-ES is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"es-es\\":{\\"resources\\":\\"spanish/language\\"},\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"7.0.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":336,\\"h\\":336}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
+exports[`when there is a device entry point present when there are compiled language files ensures the default language es-ES is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"es-es\\":{\\"resources\\":\\"spanish/language\\"},\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"8.1.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":336,\\"h\\":336}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
 
 exports[`when there is a device entry point present when there are compiled language files sets the i18n[lang].resources key for language files that pass through 1`] = `
 Object {
-  "apiVersion": "7.0.0",
+  "apiVersion": "8.1.0",
   "appManifestVersion": 1,
   "appType": "clockface",
   "buildId": "0x0f75775f470c1585",

--- a/src/buildTargets.test.ts
+++ b/src/buildTargets.test.ts
@@ -23,14 +23,14 @@ jest.mock(
   { virtual: true },
 );
 
-jest.mock('./sdkVersion', () => jest.fn(() => semver.parse('5.0.0')));
+jest.mock('./sdkVersion', () => jest.fn(() => semver.parse('6.0.0')));
 
 function mockSDKVersion(version: string) {
   (sdkVersion as jest.Mock).mockReturnValue(semver.parse(version));
 }
 
 it('merges the build target descriptors', () => {
-  mockSDKVersion('5.0.0');
+  mockSDKVersion('6.0.0');
   expect(generateBuildTargets()).toMatchObject({
     atlas: {
       displayName: 'Fitbit Versa 3',

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -17,7 +17,7 @@ expect.addSnapshotSerializer(cwdSerializer);
 
 let mockDiagnosticHandler: jest.Mock;
 
-jest.mock('./sdkVersion', () => jest.fn(() => semver.parse('5.0.0')));
+jest.mock('./sdkVersion', () => jest.fn(() => semver.parse('6.0.0')));
 
 function mockSDKVersion(version: string) {
   (sdkVersion as jest.Mock).mockReturnValue(semver.parse(version));
@@ -25,7 +25,7 @@ function mockSDKVersion(version: string) {
 
 beforeEach(() => {
   mockDiagnosticHandler = jest.fn();
-  mockSDKVersion('5.0.0');
+  mockSDKVersion('6.0.0');
 
   // We don't want to load the actual tsconfig.json for this project
   // during unit tests. Using a real tsconfig.json located within
@@ -234,10 +234,11 @@ it('emits multiple chunks when dynamic import are used', async () => {
   expect(chunkJS).toMatchSnapshot();
 });
 
-describe('when building a device component which uses a module without default exports', () => {
+describe('when building a device component which uses a module without default exports on SDK 5.0', () => {
   let file: string;
 
   beforeEach(async () => {
+    mockSDKVersion('5.0.0');
     file = await compileFile('noDefaultExport.js', {
       component: ComponentType.DEVICE,
     }).then(getVinylContents);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -23,6 +23,7 @@ import workaroundRequireScope from './plugins/workaroundRequireScope';
 import terser from './plugins/terser';
 import typescript from './plugins/typescript';
 import rollupWarningHandler from './rollupWarningHandler';
+import sdkVersion from './sdkVersion';
 
 // TODO: emit a warning when any of these settings are
 // defined in the app's tsconfig
@@ -167,9 +168,11 @@ export default function compile({
         }
 
         // Some of the built-in modules do not have a default export.
+        // Pretend one exists for compatibility reasons up to SDK 6.0
         if (
           component === ComponentType.DEVICE &&
-          deviceModulesWithoutDefaultExports.has(id)
+          deviceModulesWithoutDefaultExports.has(id) &&
+          sdkVersion().major < 6
         ) {
           return 'auto';
         }

--- a/src/sdkVersion.test.ts
+++ b/src/sdkVersion.test.ts
@@ -9,10 +9,10 @@ it('throws if package version is invalid', () => {
   expect(() => apiVersions({}, '..')).toThrowErrorMatchingSnapshot();
 });
 
-it('provides a mapping for SDKv5.0', () => {
-  expect(apiVersions({}, '5.0.0')).toEqual({
-    deviceApi: '7.0.0',
-    companionApi: '3.1.0',
+it('provides a mapping for SDKv6.0', () => {
+  expect(apiVersions({}, '6.0.0')).toEqual({
+    deviceApi: '8.1.0',
+    companionApi: '3.3.0',
   });
 });
 
@@ -24,9 +24,9 @@ it('provides a mapping for a known SDK version with a non-zero patch version', (
 });
 
 it('provides a mapping for a known SDK version with a pre-release suffix', () => {
-  expect(apiVersions({}, '5.0.0-alpha.1')).toEqual({
-    deviceApi: '7.0.0',
-    companionApi: '3.1.0',
+  expect(apiVersions({}, '6.0.0-alpha.1')).toEqual({
+    deviceApi: '8.1.0',
+    companionApi: '3.3.0',
   });
 });
 
@@ -52,20 +52,20 @@ describe('given a specific toolchain version', () => {
   let version: SemVer;
 
   beforeEach(() => {
-    version = sdkVersion('5.0.5-pre.7');
+    version = sdkVersion('6.0.5-pre.7');
   });
 
   it('converts the toolchain version to an SDK version', () => {
     expect(version).toMatchObject({
-      major: 5,
+      major: 6,
       minor: 0,
       patch: 0,
       prerelease: [],
-      version: '5.0.0',
+      version: '6.0.0',
     });
   });
 
   it('returns an SDK version that compares as expected', () => {
-    expect(satisfies(version, '>=5.0.0')).toBe(true);
+    expect(satisfies(version, '>=6.0.0')).toBe(true);
   });
 });


### PR DESCRIPTION
We kept this in place before because previously `import fs from 'fs'` worked even though `fs` actually has no default export, but Rollup interop made it transparently work as if it did (and equivalent to `import * as fs from 'fs'`. Rollup has now changed this behaviour slightly in a way that's incompatible with our firmware implementation that puts module members on the prototype.

To resolve this, I re-released 4.2.2 and 5.0.2 with the newest Rollup before the change pinned as a dependency to return the original behaviour, but for SDK 6.0 we can safely drop this technically incorrect code and ask developers to fix their apps I think. Thoughts?

Signed-off-by: Liam McLoughlin <lmcloughlin@google.com>