### PR TITLE
Add SDK 4.3 target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fitbit/sdk",
-  "version": "6.0.0-pre.9",
+  "version": "4.3.0-pre.0",
   "description": "Toolchain for building Fitbit apps",
   "author": "Fitbit, Inc.",
   "license": "BSD-3-Clause",
@@ -91,7 +91,7 @@
     "playback-stream": "^1.0.0",
     "plugin-error": "^1.0.1",
     "pofile": "^1.1.0",
-    "rollup": "^2.36.2",
+    "rollup": "^2.41.3",
     "semver": "^7.3.4",
     "simple-random": "^1.0.3",
     "source-map": "^0.7.3",

--- a/src/ProjectConfiguration.test.ts
+++ b/src/ProjectConfiguration.test.ts
@@ -333,7 +333,7 @@ it('validationErrors() validates all fields', () => {
     expect.objectContaining({
       category: DiagnosticCategory.Error,
       messageText:
-        'Default language is an invalid language tag: _invalid_. Must be en-US, de-DE, es-ES, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, sv-SE, zh-CN, zh-TW, pt-BR, id-ID, ro-RO, ru-RU, pl-PL, cs-CZ or nb-NO.',
+        'Default language is an invalid language tag: _invalid_. Must be en-US, de-DE, es-ES, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, sv-SE, zh-CN, zh-TW, pt-BR, id-ID, ro-RO, ru-RU, pl-PL or cs-CZ.',
     }),
     expect.objectContaining({
       category: DiagnosticCategory.Error,
@@ -466,7 +466,7 @@ it('validates the default language is a valid language tag', () => {
     expect.objectContaining({
       category: DiagnosticCategory.Error,
       messageText:
-        'Default language is an invalid language tag: _really_not_bcp_47_. Must be en-US, de-DE, es-ES, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, sv-SE, zh-CN, zh-TW, pt-BR, id-ID, ro-RO, ru-RU, pl-PL, cs-CZ or nb-NO.',
+        'Default language is an invalid language tag: _really_not_bcp_47_. Must be en-US, de-DE, es-ES, fr-FR, it-IT, ja-JP, ko-KR, nl-NL, sv-SE, zh-CN, zh-TW, pt-BR, id-ID, ro-RO, ru-RU, pl-PL or cs-CZ.',
     }),
   );
 });

--- a/src/ProjectConfiguration.ts
+++ b/src/ProjectConfiguration.ts
@@ -81,7 +81,6 @@ export enum Locales {
   'ru-RU' = 'Russian',
   'pl-PL' = 'Polish',
   'cs-CZ' = 'Czech',
-  'nb-NO' = 'Norwegian (Bokmål)',
 }
 
 const languageTags = Object.keys(Locales);

--- a/src/__snapshots__/appPackageManifest.test.ts.snap
+++ b/src/__snapshots__/appPackageManifest.test.ts.snap
@@ -6,15 +6,15 @@ Object {
   "buildId": "0x0f75775f470c1585",
   "components": Object {
     "watch": Object {
-      "atlas": Object {
-        "filename": "device-atlas.zip",
+      "higgs": Object {
+        "filename": "device-higgs.zip",
         "platform": Array [
-          "128.1.1+",
+          "30.1.2+",
         ],
         "supports": Object {
           "screenSize": Object {
-            "h": 336,
-            "w": 336,
+            "h": 250,
+            "w": 348,
           },
         },
       },
@@ -27,7 +27,7 @@ Object {
   },
   "sourceMaps": Object {
     "device": Object {
-      "atlas": "sourceMaps/device/atlas/index.js.json",
+      "higgs": "sourceMaps/device/higgs/index.js.json",
     },
   },
 }
@@ -42,15 +42,15 @@ Object {
       "filename": "companion.zip",
     },
     "watch": Object {
-      "atlas": Object {
-        "filename": "device-atlas.zip",
+      "higgs": Object {
+        "filename": "device-higgs.zip",
         "platform": Array [
-          "128.1.1+",
+          "30.1.2+",
         ],
         "supports": Object {
           "screenSize": Object {
-            "h": 336,
-            "w": 336,
+            "h": 250,
+            "w": 348,
           },
         },
       },
@@ -65,7 +65,7 @@ Object {
   "sourceMaps": Object {
     "companion": "sourceMaps/companion/companion.js.json",
     "device": Object {
-      "atlas": "sourceMaps/device/atlas/index.js.json",
+      "higgs": "sourceMaps/device/higgs/index.js.json",
     },
     "settings": "sourceMaps/settings/settings.js.json",
   },
@@ -78,10 +78,10 @@ Object {
   "buildId": "0x0f75775f470c1585",
   "components": Object {
     "watch": Object {
-      "atlas": Object {
-        "filename": "device-atlas.zip",
+      "higgs": Object {
+        "filename": "device-higgs.zip",
         "platform": Array [
-          "128.1.1+",
+          "30.1.2+",
         ],
       },
     },
@@ -101,10 +101,10 @@ Object {
       "filename": "companion.zip",
     },
     "watch": Object {
-      "atlas": Object {
-        "filename": "device-atlas.zip",
+      "higgs": Object {
+        "filename": "device-higgs.zip",
         "platform": Array [
-          "128.1.1+",
+          "30.1.2+",
         ],
       },
     },
@@ -127,27 +127,27 @@ Object {
   "buildId": "0x0f75775f470c1585",
   "components": Object {
     "watch": Object {
-      "atlas": Object {
-        "filename": "device-atlas.zip",
+      "higgs": Object {
+        "filename": "device-higgs.zip",
         "platform": Array [
-          "128.1.1+",
+          "30.1.2+",
         ],
         "supports": Object {
           "screenSize": Object {
-            "h": 336,
-            "w": 336,
+            "h": 250,
+            "w": 348,
           },
         },
       },
-      "vulcan": Object {
-        "filename": "device-vulcan.zip",
+      "mira": Object {
+        "filename": "device-mira.zip",
         "platform": Array [
-          "128.1.1+",
+          "68.9.12+",
         ],
         "supports": Object {
           "screenSize": Object {
-            "h": 336,
-            "w": 336,
+            "h": 300,
+            "w": 300,
           },
         },
       },
@@ -160,8 +160,8 @@ Object {
   },
   "sourceMaps": Object {
     "device": Object {
-      "atlas": "sourceMaps/device/atlas/index.js.json",
-      "vulcan": "sourceMaps/device/vulcan/index.js.json",
+      "higgs": "sourceMaps/device/higgs/index.js.json",
+      "mira": "sourceMaps/device/mira/index.js.json",
     },
   },
 }
@@ -173,27 +173,27 @@ Object {
   "buildId": "0x0f75775f470c1585",
   "components": Object {
     "watch": Object {
-      "atlas": Object {
-        "filename": "device-atlas.zip",
+      "higgs": Object {
+        "filename": "device-higgs.zip",
         "platform": Array [
-          "128.1.1+",
+          "30.1.2+",
         ],
         "supports": Object {
           "screenSize": Object {
-            "h": 336,
-            "w": 336,
+            "h": 250,
+            "w": 348,
           },
         },
       },
-      "vulcan": Object {
-        "filename": "device-vulcan.zip",
+      "mira": Object {
+        "filename": "device-mira.zip",
         "platform": Array [
-          "128.1.1+",
+          "68.9.12+",
         ],
         "supports": Object {
           "screenSize": Object {
-            "h": 336,
-            "w": 336,
+            "h": 300,
+            "w": 300,
           },
         },
       },
@@ -206,8 +206,8 @@ Object {
   },
   "sourceMaps": Object {
     "device": Object {
-      "atlas": "sourceMaps/device/atlas/index.js.json",
-      "vulcan": "sourceMaps/device/vulcan/index.js.json",
+      "higgs": "sourceMaps/device/higgs/index.js.json",
+      "mira": "sourceMaps/device/mira/index.js.json",
     },
   },
 }
@@ -225,4 +225,4 @@ exports[`emits an error if both JS and native device components are present 1`] 
 
 exports[`emits an error if multiple companion bundles are present for the same device family 1`] = `"Duplicate companion component bundles: bundle1.zip / bundle0.zip"`;
 
-exports[`emits an error if multiple device bundles are present for the same device family 1`] = `"Duplicate device/atlas component bundles: bundle1.zip / bundle0.zip"`;
+exports[`emits an error if multiple device bundles are present for the same device family 1`] = `"Duplicate device/higgs component bundles: bundle1.zip / bundle0.zip"`;

--- a/src/__snapshots__/compile.test.ts.snap
+++ b/src/__snapshots__/compile.test.ts.snap
@@ -183,7 +183,7 @@ Array [
 ]
 `;
 
-exports[`when building a device component which uses a module without default exports on SDK 5.0 patches generated code to use the module namespace as the default export 1`] = `
+exports[`when building a device component which uses a module without default exports on SDK 4.3 patches generated code to use the module namespace as the default export 1`] = `
 "\\"use strict\\"
 var e=require(\\"crypto\\"),o=require(\\"document\\"),t=require(\\"fs\\"),f=require(\\"jpeg\\"),l=require(\\"power\\"),r=require(\\"scientific\\"),s=require(\\"scientific/signal\\"),u=require(\\"system\\"),i=require(\\"user-activity\\"),p=require(\\"user-settings\\")
 function y(e){return e&&e.__esModule?e:{default:e}}var c=y(e),n=y(o),a=y(t),g=y(f),d=y(l),q=y(r),m=y(s),v=y(u),j=y(i),w=y(p)

--- a/src/__snapshots__/compileTranslations.test.ts.snap
+++ b/src/__snapshots__/compileTranslations.test.ts.snap
@@ -38,7 +38,7 @@ PluginError {
 exports[`rejects .po files whose names are not acceptable language tags e.po 1`] = `
 PluginError {
   "fileName": "e.po",
-  "message": "Translation file e.po has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.",
+  "message": "Translation file e.po has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.",
   "name": "Error",
   "plugin": "compileTranslations",
 }
@@ -47,7 +47,7 @@ PluginError {
 exports[`rejects .po files whose names are not acceptable language tags en-USA.po 1`] = `
 PluginError {
   "fileName": "en-USA.po",
-  "message": "Translation file en-USA.po has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.",
+  "message": "Translation file en-USA.po has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.",
   "name": "Error",
   "plugin": "compileTranslations",
 }
@@ -56,7 +56,7 @@ PluginError {
 exports[`rejects .po files whose names are not acceptable language tags sl-IT-nedis.po 1`] = `
 PluginError {
   "fileName": "sl-IT-nedis.po",
-  "message": "Translation file sl-IT-nedis.po has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.",
+  "message": "Translation file sl-IT-nedis.po has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.",
   "name": "Error",
   "plugin": "compileTranslations",
 }

--- a/src/__snapshots__/componentManifest.test.ts.snap
+++ b/src/__snapshots__/componentManifest.test.ts.snap
@@ -168,8 +168,8 @@ Object {
   "requestedPermissions": Array [],
   "supports": Object {
     "screenSize": Object {
-      "h": 336,
-      "w": 336,
+      "h": 250,
+      "w": 348,
     },
   },
   "svgMain": "resources/index.view",
@@ -198,8 +198,8 @@ Object {
   "requestedPermissions": Array [],
   "supports": Object {
     "screenSize": Object {
-      "h": 336,
-      "w": 336,
+      "h": 250,
+      "w": 348,
     },
   },
   "uuid": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
@@ -226,8 +226,8 @@ Object {
   "requestedPermissions": Array [],
   "supports": Object {
     "screenSize": Object {
-      "h": 336,
-      "w": 336,
+      "h": 250,
+      "w": 348,
     },
   },
   "svgMain": "resources/index.view",
@@ -257,8 +257,8 @@ Object {
   "requestedPermissions": Array [],
   "supports": Object {
     "screenSize": Object {
-      "h": 336,
-      "w": 336,
+      "h": 250,
+      "w": 348,
     },
   },
   "svgMain": "resources/index.view",
@@ -268,9 +268,9 @@ Object {
 }
 `;
 
-exports[`when there is a device entry point present when there are compiled language files ensures the default language en-US is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"},\\"es-es\\":{\\"resources\\":\\"spanish/language\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"8.1.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":336,\\"h\\":336}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
+exports[`when there is a device entry point present when there are compiled language files ensures the default language en-US is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"},\\"es-es\\":{\\"resources\\":\\"spanish/language\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"8.1.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":348,\\"h\\":250}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
 
-exports[`when there is a device entry point present when there are compiled language files ensures the default language es-ES is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"es-es\\":{\\"resources\\":\\"spanish/language\\"},\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"8.1.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":336,\\"h\\":336}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
+exports[`when there is a device entry point present when there are compiled language files ensures the default language es-ES is the first key in the i18n object 1`] = `"{\\"appType\\":\\"clockface\\",\\"i18n\\":{\\"es-es\\":{\\"resources\\":\\"spanish/language\\"},\\"en-us\\":{\\"name\\":\\"My App\\",\\"resources\\":\\"lang/english\\"},\\"fr-fr\\":{\\"name\\":\\"Mon application\\"}},\\"appManifestVersion\\":1,\\"main\\":\\"device/index.js\\",\\"apiVersion\\":\\"8.1.0\\",\\"buildId\\":\\"0x0f75775f470c1585\\",\\"bundleDate\\":\\"2018-06-27T00:00:00.000Z\\",\\"uuid\\":\\"b4ae822e-eca9-4fcb-8747-217f2a1f53a1\\",\\"name\\":\\"My App\\",\\"requestedPermissions\\":[],\\"supports\\":{\\"screenSize\\":{\\"w\\":348,\\"h\\":250}},\\"svgMain\\":\\"resources/index.view\\",\\"svgWidgets\\":\\"resources/widget.defs\\"}"`;
 
 exports[`when there is a device entry point present when there are compiled language files sets the i18n[lang].resources key for language files that pass through 1`] = `
 Object {
@@ -296,8 +296,8 @@ Object {
   "requestedPermissions": Array [],
   "supports": Object {
     "screenSize": Object {
-      "h": 336,
-      "w": 336,
+      "h": 250,
+      "w": 348,
     },
   },
   "svgMain": "resources/index.view",

--- a/src/appPackageManifest.test.ts
+++ b/src/appPackageManifest.test.ts
@@ -24,7 +24,7 @@ const makeProjectConfig = (): ClockProjectConfiguration => ({
     en: { name: 'My App' },
     fr: { name: 'Mon application' },
   },
-  buildTargets: ['atlas'],
+  buildTargets: ['higgs'],
   requestedPermissions: [],
   defaultLanguage: 'en-US',
 });
@@ -118,7 +118,7 @@ it('builds a package manifest with multiple device components', () =>
   expectValidPackageManifest({
     projectConfig: {
       ...makeProjectConfig(),
-      buildTargets: ['atlas', 'vulcan'],
+      buildTargets: ['higgs', 'mira'],
     },
   }).toMatchSnapshot());
 
@@ -126,7 +126,7 @@ it('builds a package manifest with supported capabilities', () =>
   expectValidPackageManifest({
     projectConfig: {
       ...makeProjectConfig(),
-      buildTargets: ['atlas', 'vulcan'],
+      buildTargets: ['higgs', 'mira'],
       enableProposedAPI: true,
     },
   }).toMatchSnapshot());
@@ -138,7 +138,7 @@ it('emits an error if both JS and native device components are present', () => {
     new Vinyl({
       componentBundle: {
         type: 'device',
-        family: 'atlas',
+        family: 'higgs',
         platform: ['1.1.1+'],
       },
       path: 'bundle.zip',
@@ -175,7 +175,7 @@ it.each(['device', 'companion'])(
         new Vinyl({
           componentBundle: {
             type: component,
-            family: 'atlas',
+            family: 'higgs',
             platform: ['1.1.1+'],
           },
           path: `bundle${i}.zip`,
@@ -205,7 +205,7 @@ it.each<[string, any]>([
   ['has an invalid type field', { type: '__invalid__' }],
   [
     'has a device type but missing platform',
-    { type: 'device', family: 'atlas' },
+    { type: 'device', family: 'higgs' },
   ],
   [
     'has a device type but missing family',
@@ -213,7 +213,7 @@ it.each<[string, any]>([
   ],
   [
     'has a device type but invalid platform',
-    { type: 'device', family: 'atlas', platform: '1.1.1+' },
+    { type: 'device', family: 'higgs', platform: '1.1.1+' },
   ],
 ])('emits an error if a component bundle tag %s', (_, componentBundle) => {
   const projectConfig = makeProjectConfig();

--- a/src/buildTargets.test.ts
+++ b/src/buildTargets.test.ts
@@ -32,11 +32,11 @@ function mockSDKVersion(version: string) {
 it('merges the build target descriptors', () => {
   mockSDKVersion('6.0.0');
   expect(generateBuildTargets()).toMatchObject({
-    atlas: {
-      displayName: 'Fitbit Versa 3',
+    higgs: {
+      displayName: 'Fitbit Ionic',
       platform: expect.any(Array),
-      resourceFilterTag: '336x336',
-      specs: { screenSize: { width: 336, height: 336 } },
+      resourceFilterTag: '348x250',
+      specs: { screenSize: { width: 348, height: 250 } },
     },
     // Unfortunately, due to the way that module mocking works, the
     // extra build targets constant cannot be deduped easily.

--- a/src/buildTargets.ts
+++ b/src/buildTargets.ts
@@ -18,29 +18,32 @@ export interface BuildTargetDescriptor {
 }
 
 const baseBuildTargets: { [platform: string]: BuildTargetDescriptor } = {
-  atlas: {
-    displayName: 'Fitbit Versa 3',
-    minSDKVersion: '5.0.0',
-    platform: ['128.1.1+'],
-    resourceFilterTag: '336x336',
-    specs: {
-      screenSize: {
-        width: 336,
-        height: 336,
-      },
-    },
+  higgs: {
+    displayName: 'Fitbit Ionic',
+    platform: ['30.1.2+'],
+    resourceFilterTag: '348x250',
+    specs: { screenSize: { width: 348, height: 250 } },
   },
-  vulcan: {
-    displayName: 'Fitbit Sense',
-    minSDKVersion: '5.0.0',
-    platform: ['128.1.1+'],
-    resourceFilterTag: '336x336',
-    specs: {
-      screenSize: {
-        width: 336,
-        height: 336,
-      },
-    },
+  meson: {
+    displayName: 'Fitbit Versa',
+    platform: ['32.4.18+'],
+    resourceFilterTag: '300x300',
+    specs: { screenSize: { width: 300, height: 300 } },
+  },
+  gemini: {
+    displayName: 'Fitbit Versa Lite',
+    platform: ['33.1.30+'],
+    resourceFilterTag: '300x300',
+    specs: { screenSize: { width: 300, height: 300 } },
+    minSDKVersion: '3.1.0',
+    maxDeviceBundleSize: 3145728,
+  },
+  mira: {
+    displayName: 'Fitbit Versa 2',
+    platform: ['68.9.12+'],
+    resourceFilterTag: '300x300',
+    specs: { screenSize: { width: 300, height: 300 } },
+    minSDKVersion: '4.0.0',
   },
 };
 

--- a/src/capabilities.test.ts
+++ b/src/capabilities.test.ts
@@ -3,15 +3,15 @@ import { SupportedDeviceCapabilities } from './capabilities';
 describe('SupportedDeviceCapabilities', () => {
   describe('create()', () => {
     it('returns supported capabilities for * as JS API version', () => {
-      expect(SupportedDeviceCapabilities.create('atlas')).toEqual(
+      expect(SupportedDeviceCapabilities.create('higgs')).toEqual(
         expect.objectContaining({
-          screenSize: { w: 336, h: 336 },
+          screenSize: { w: 348, h: 250 },
         }),
       );
 
-      expect(SupportedDeviceCapabilities.create('vulcan')).toEqual(
+      expect(SupportedDeviceCapabilities.create('mira')).toEqual(
         expect.objectContaining({
-          screenSize: { w: 336, h: 336 },
+          screenSize: { w: 300, h: 300 },
         }),
       );
     });

--- a/src/compile.test.ts
+++ b/src/compile.test.ts
@@ -17,7 +17,7 @@ expect.addSnapshotSerializer(cwdSerializer);
 
 let mockDiagnosticHandler: jest.Mock;
 
-jest.mock('./sdkVersion', () => jest.fn(() => semver.parse('6.0.0')));
+jest.mock('./sdkVersion', () => jest.fn(() => semver.parse('4.3.0')));
 
 function mockSDKVersion(version: string) {
   (sdkVersion as jest.Mock).mockReturnValue(semver.parse(version));
@@ -25,7 +25,7 @@ function mockSDKVersion(version: string) {
 
 beforeEach(() => {
   mockDiagnosticHandler = jest.fn();
-  mockSDKVersion('6.0.0');
+  mockSDKVersion('4.3.0');
 
   // We don't want to load the actual tsconfig.json for this project
   // during unit tests. Using a real tsconfig.json located within
@@ -234,11 +234,11 @@ it('emits multiple chunks when dynamic import are used', async () => {
   expect(chunkJS).toMatchSnapshot();
 });
 
-describe('when building a device component which uses a module without default exports on SDK 5.0', () => {
+describe('when building a device component which uses a module without default exports on SDK 4.3', () => {
   let file: string;
 
   beforeEach(async () => {
-    mockSDKVersion('5.0.0');
+    mockSDKVersion('4.3.0');
     file = await compileFile('noDefaultExport.js', {
       component: ComponentType.DEVICE,
     }).then(getVinylContents);

--- a/src/componentManifest.test.ts
+++ b/src/componentManifest.test.ts
@@ -30,7 +30,7 @@ const makeClockfaceProjectConfig = (): ClockProjectConfiguration => ({
     'en-US': { name: 'My App' },
     'fr-FR': { name: 'Mon application' },
   },
-  buildTargets: ['atlas'],
+  buildTargets: ['higgs'],
   requestedPermissions: [],
   defaultLanguage: 'en-US',
 });
@@ -71,7 +71,7 @@ function makeDeviceManifestStream(
     makeDeviceManifest({
       buildId,
       projectConfig,
-      targetDevice: 'atlas',
+      targetDevice: 'higgs',
     }),
   );
 }

--- a/src/plugins/__snapshots__/companionTranslations.test.ts.snap
+++ b/src/plugins/__snapshots__/companionTranslations.test.ts.snap
@@ -18,12 +18,12 @@ exports[`throws if the default language is not found 1`] = `[Error: No translati
 
 exports[`throws when a translation file has multiple msgstr values for the same msgid 1`] = `[Error: msgid "foo" in file "<base>/multiple-msgstr/en-US.po" has multiple msgstr values. This is not supported.]`;
 
-exports[`throws when encountering the badly named file ".po" 1`] = `[Error: Translation file "<base>/bad-name/.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.]`;
+exports[`throws when encountering the badly named file ".po" 1`] = `[Error: Translation file "<base>/bad-name/.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.]`;
 
-exports[`throws when encountering the badly named file "a.po" 1`] = `[Error: Translation file "<base>/bad-name/a.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.]`;
+exports[`throws when encountering the badly named file "a.po" 1`] = `[Error: Translation file "<base>/bad-name/a.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.]`;
 
-exports[`throws when encountering the badly named file "english.po" 1`] = `[Error: Translation file "<base>/bad-name/english.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.]`;
+exports[`throws when encountering the badly named file "english.po" 1`] = `[Error: Translation file "<base>/bad-name/english.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.]`;
 
-exports[`throws when encountering the badly named file "enus.po" 1`] = `[Error: Translation file "<base>/bad-name/enus.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po, cs-CZ.po or nb-NO.po.]`;
+exports[`throws when encountering the badly named file "enus.po" 1`] = `[Error: Translation file "<base>/bad-name/enus.po" has a bad name. Translation files must be named en-US.po, de-DE.po, es-ES.po, fr-FR.po, it-IT.po, ja-JP.po, ko-KR.po, nl-NL.po, sv-SE.po, zh-CN.po, zh-TW.po, pt-BR.po, id-ID.po, ro-RO.po, ru-RU.po, pl-PL.po or cs-CZ.po.]`;
 
 exports[`throws when multiple files map to the same language 1`] = `[Error: More than one translation file found for language en-US. Found "<base>/language-collision/en-US.po" and "<base>/language-collision/lang/en-US.po".]`;

--- a/src/plugins/platformExternals.ts
+++ b/src/plugins/platformExternals.ts
@@ -18,7 +18,6 @@ const common = [
 
 const device = [
   'accelerometer',
-  'app-cluster-storage',
   'appbit',
   'barometer',
   'body-presence',

--- a/src/sdkVersion.ts
+++ b/src/sdkVersion.ts
@@ -13,6 +13,7 @@ interface WithProposedAPI {
 }
 
 const apiBySdk: Record<string, ApiVersions> = {
+  '4.3': { deviceApi: '6.0.0', companionApi: '3.3.0' },
   '5.0': { deviceApi: '7.0.0', companionApi: '3.1.0' },
   '5.1': { deviceApi: '7.1.0', companionApi: '3.1.0' },
   '6.0': { deviceApi: '8.1.0', companionApi: '3.3.0' },

--- a/src/validateIcon.test.ts
+++ b/src/validateIcon.test.ts
@@ -26,7 +26,7 @@ const projectConfig: ProjectConfiguration = {
     en: { name: 'My App' },
     fr: { name: 'Mon application' },
   },
-  buildTargets: ['atlas'],
+  buildTargets: ['higgs'],
   requestedPermissions: ['permission'],
   defaultLanguage: 'en-US',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4885,10 +4885,10 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^2.36.2:
-  version "2.45.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.45.2.tgz#8fb85917c9f35605720e92328f3ccbfba6f78b48"
-  integrity sha512-kRRU7wXzFHUzBIv0GfoFFIN3m9oteY4uAsKllIpQDId5cfnkWF2J130l+27dzDju0E6MScKiV0ZM5Bw8m4blYQ==
+rollup@^2.41.3:
+  version "2.50.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.50.5.tgz#bbee9d6411af3f5fa5c6e7e2c69f7a65b753e568"
+  integrity sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==
   optionalDependencies:
     fsevents "~2.3.1"
 


### PR DESCRIPTION
Re-added a 4.3 target, fixed the tests to point to a pre-Atlas device and 4.3 version so they work again.

Kept Rollup pinned to the current 4.2 version to avoid introducing the default exports breaking change we made in 6.0.

Merging to a branch that's a copy of master to enable review of changes, will delete once the 4.3 release is done and just keep the tags.

Signed-off-by: Liam McLoughlin <lmcloughlin@google.com>