### PR TITLE
Pin Rollup to 2.41.3 to avoid namespace import behaviour change [cherry-pick from 4.2.2 to 4.3 branch]

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "playback-stream": "^1.0.0",
     "plugin-error": "^1.0.1",
     "pofile": "^1.1.0",
-    "rollup": "^2.41.3",
+    "rollup": "2.41.3",
     "semver": "^7.3.4",
     "simple-random": "^1.0.3",
     "source-map": "^0.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4905,10 +4905,10 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rollup@^2.41.3:
-  version "2.50.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.50.5.tgz#bbee9d6411af3f5fa5c6e7e2c69f7a65b753e568"
-  integrity sha512-Ztz4NurU2LbS3Jn5rlhnYv35z6pkjBUmYKr94fOBIKINKRO6kug9NTFHArT7jqwMP2kqEZ39jJuEtkk91NBltQ==
+rollup@2.41.3:
+  version "2.41.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.41.3.tgz#b224f3863a1660e9d5233ffd2fa0800d90f66433"
+  integrity sha512-swrSUfX3UK7LGd5exBJNUC7kykdxemUTRuyO9hUFJsmQUsUovHcki9vl5MAWFbB6oI47HpeZHtbmuzdm1SRUZw==
   optionalDependencies:
     fsevents "~2.3.1"
 


### PR DESCRIPTION
This avoids https://github.com/rollup/rollup/issues/4009

Signed-off-by: Liam McLoughlin <lmcloughlin@google.com>