### PR TITLE
Add tile support

### DIFF
--- a/src/ProjectConfiguration.ts
+++ b/src/ProjectConfiguration.ts
@@ -16,6 +16,17 @@ export enum AppType {
   SERVICE = 'service',
 }
 
+/**
+ * Tile specification
+ * If the buildTargets field is missing tile will
+ * be available to all app buildTargets
+ */
+export interface Tile {
+  name: string;
+  uuid: string;
+  buildTargets?: string[];
+}
+
 export const VALID_APP_TYPES = Object.values(AppType);
 
 export const MAX_LENGTH_APP_CLUSTER_ID = 64;
@@ -44,6 +55,7 @@ export interface AppProjectConfiguration extends BaseProjectConfiguration {
   appType: AppType.APP;
   wipeColor: string;
   iconFile: string;
+  tiles?: Tile[];
 }
 
 export interface ClockProjectConfiguration extends BaseProjectConfiguration {
@@ -54,7 +66,7 @@ export interface ServiceProjectConfiguration extends BaseProjectConfiguration {
   appType: AppType.SERVICE;
 }
 
-type ProjectConfiguration =
+export type ProjectConfiguration =
   | AppProjectConfiguration
   | ClockProjectConfiguration
   | ServiceProjectConfiguration;
@@ -623,6 +635,63 @@ export function validateCompanionDefaultWakeInterval(
   return diagnostics;
 }
 
+export function validateTileComponentAppType(config: ProjectConfiguration) {
+  const diagnostics = new DiagnosticList();
+
+  // Tiles are available just for appType = APP
+  // @ts-ignore
+  if (config.appType !== AppType.APP && config.tiles !== undefined) {
+    diagnostics.pushWarning(
+      'Tiles available only for APPS. Skipping tile configuration!',
+    );
+  }
+
+  return diagnostics;
+}
+
+export function validateTileBuildTarget(
+  tile: Tile,
+  { buildTargets }: AppProjectConfiguration,
+) {
+  if (tile.buildTargets !== undefined) {
+    return constrainedSetDiagnostics({
+      actualValues: tile.buildTargets,
+      knownValues: buildTargets,
+      valueTypeNoun: 'tile build targets',
+      notFoundIsFatal: true,
+    });
+  }
+
+  // Return empty list. Nothing to check
+  return new DiagnosticList();
+}
+
+export function validateTileUUID(tile: Tile, config: AppProjectConfiguration) {
+  const diagnostic = new DiagnosticList();
+  if (tile.uuid === undefined) {
+    diagnostic.pushFatalError("Tile UUID can't be undefined");
+  }
+
+  if (!validator.isUUID(String(tile.uuid))) {
+    diagnostic.pushFatalError('Tile UUID must be a valid UUID');
+  }
+
+  const knownUUID = config.tiles?.map((tile) => tile.uuid);
+  if (knownUUID?.indexOf(tile.uuid) !== knownUUID?.lastIndexOf(tile.uuid)) {
+    diagnostic.pushFatalError("Can't have duplicate UUIDs between tiles");
+  }
+
+  return diagnostic;
+}
+
+export function validateTileName(tile: Tile, config: AppProjectConfiguration) {
+  const diagnostic = new DiagnosticList();
+  if (tile.name === undefined) {
+    diagnostic.pushFatalError('Tile name must be specified');
+  }
+  return diagnostic;
+}
+
 interface ValidationOptions {
   hasNativeComponents?: boolean;
 }
@@ -648,7 +717,20 @@ export function validate(
     validateDefaultLanguage,
     validateStorageGroup,
     validateCompanionDefaultWakeInterval,
+    validateTileComponentAppType,
   ].forEach((validator) => diagnostics.extend(validator(config)));
   diagnostics.extend(validateBuildTarget(config, { hasNativeComponents }));
+
+  if (config.appType === AppType.APP) {
+    const appConfig = config;
+    [validateTileBuildTarget, validateTileUUID, validateTileName].forEach(
+      (validator) => {
+        appConfig.tiles?.forEach((tile) =>
+          diagnostics.extend(validator(tile, appConfig)),
+        );
+      },
+    );
+  }
+
   return diagnostics;
 }

--- a/src/__snapshots__/appPackageManifest.test.ts.snap
+++ b/src/__snapshots__/appPackageManifest.test.ts.snap
@@ -213,6 +213,102 @@ Object {
 }
 `;
 
+exports[`builds a package with tiles component 1`] = `
+Object {
+  "appId": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
+  "buildId": "0x0f75775f470c1585",
+  "components": Object {
+    "tiles": Array [
+      Object {
+        "id": "b4ae822e-eca9-4fcb-8747-217f2a1f53a2",
+        "name": "Tile1",
+        "platforms": Array [
+          "atlas",
+          "vulcan",
+        ],
+      },
+      Object {
+        "id": "b4ae822e-eca9-4fcb-8747-217f2a1f53a3",
+        "name": "Tile2",
+        "platforms": Array [
+          "atlas",
+        ],
+      },
+    ],
+    "watch": Object {
+      "atlas": Object {
+        "filename": "device-atlas.zip",
+        "platform": Array [
+          "128.1.1+",
+        ],
+        "supports": Object {
+          "screenSize": Object {
+            "h": 336,
+            "w": 336,
+          },
+        },
+      },
+      "vulcan": Object {
+        "filename": "device-vulcan.zip",
+        "platform": Array [
+          "128.1.1+",
+        ],
+        "supports": Object {
+          "screenSize": Object {
+            "h": 336,
+            "w": 336,
+          },
+        },
+      },
+    },
+  },
+  "manifestVersion": 6,
+  "requestedPermissions": Array [],
+  "sdkVersion": Object {
+    "deviceApi": "8.1.0",
+  },
+  "sourceMaps": Object {
+    "device": Object {
+      "atlas": "sourceMaps/device/atlas/index.js.json",
+      "vulcan": "sourceMaps/device/vulcan/index.js.json",
+    },
+  },
+}
+`;
+
+exports[`doesn't include tile data if app type is not APP 1`] = `
+Object {
+  "appId": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
+  "buildId": "0x0f75775f470c1585",
+  "components": Object {
+    "watch": Object {
+      "atlas": Object {
+        "filename": "device-atlas.zip",
+        "platform": Array [
+          "128.1.1+",
+        ],
+        "supports": Object {
+          "screenSize": Object {
+            "h": 336,
+            "w": 336,
+          },
+        },
+      },
+    },
+  },
+  "manifestVersion": 6,
+  "requestedPermissions": Array [],
+  "sdkVersion": Object {
+    "deviceApi": "8.1.0",
+  },
+  "sourceMaps": Object {
+    "device": Object {
+      "atlas": "sourceMaps/device/atlas/index.js.json",
+    },
+  },
+}
+`;
+
 exports[`emits an error if a component bundle tag has a device type but invalid platform 1`] = `"Unknown bundle component tag: Invalid value \\"1.1.1+\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
 
 exports[`emits an error if a component bundle tag has a device type but missing family 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/family: string"`;

--- a/src/appPackageManifest.test.ts
+++ b/src/appPackageManifest.test.ts
@@ -6,8 +6,10 @@ import appPackageManifest from './appPackageManifest';
 import buildTargets from './buildTargets';
 import { ComponentType } from './componentTargets';
 import ProjectConfiguration, {
+  AppProjectConfiguration,
   AppType,
   ClockProjectConfiguration,
+  Tile,
 } from './ProjectConfiguration';
 
 import getJSONFileFromStream from './testUtils/getJSONFileFromStream';
@@ -230,4 +232,50 @@ it.each<[string, any]>([
     stream,
     projectConfig,
   ).rejects.toThrowErrorMatchingSnapshot();
+});
+
+it('builds a package with tiles component', () => {
+  const tiles: Tile[] = [
+    {
+      name: 'Tile1',
+      uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a2',
+      // Default to all buildTargets
+    },
+    {
+      name: 'Tile2',
+      uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a3',
+      buildTargets: ['atlas'], // Explictly specify buildTargets
+    },
+  ];
+
+  const projectConfig = {
+    ...makeProjectConfig(),
+    tiles,
+    appType: AppType.APP,
+    buildTargets: ['atlas', 'vulcan'],
+  } as AppProjectConfiguration;
+
+  return expectValidPackageManifest({ projectConfig }).toMatchSnapshot();
+});
+
+it("doesn't include tile data if app type is not APP", () => {
+  const tiles: Tile[] = [
+    {
+      name: 'Tile1',
+      uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a2',
+    },
+    {
+      name: 'Tile2',
+      uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a3',
+      buildTargets: ['atlas'],
+    },
+  ];
+
+  const projectConfig = {
+    ...makeProjectConfig(),
+    tiles,
+    appType: AppType.CLOCKFACE,
+  } as ClockProjectConfiguration;
+
+  return expectValidPackageManifest({ projectConfig }).toMatchSnapshot();
 });

--- a/src/appPackageManifest.ts
+++ b/src/appPackageManifest.ts
@@ -11,11 +11,17 @@ import Vinyl from 'vinyl';
 
 import { SupportedDeviceCapabilities } from './capabilities';
 import { normalizeToPOSIX } from './pathUtils';
-import ProjectConfiguration from './ProjectConfiguration';
+import { ProjectConfiguration, AppType } from './ProjectConfiguration';
 import { apiVersions } from './sdkVersion';
 
 const manifestPath = 'manifest.json';
 const PLUGIN_NAME = 'appPackageManifest';
+
+interface Tile {
+  id: string;
+  name: string;
+  platforms: string[];
+}
 
 interface Components {
   watch?: {
@@ -28,6 +34,7 @@ interface Components {
   companion?: {
     filename: string;
   };
+  tiles?: Tile[];
 }
 
 // tslint:disable-next-line:variable-name
@@ -75,6 +82,23 @@ class AppPackageManifestTransform extends Transform {
     public buildID: string,
   ) {
     super({ objectMode: true });
+  }
+
+  private populateTileData(): void {
+    if (this.projectConfig.appType === AppType.APP) {
+      const appConfig = this.projectConfig;
+
+      if (appConfig.tiles !== undefined) {
+        this.components.tiles = appConfig.tiles.map((tile) => ({
+          name: tile.name,
+          id: tile.uuid,
+          platforms:
+            tile.buildTargets !== undefined
+              ? tile.buildTargets
+              : appConfig.buildTargets,
+        }));
+      }
+    }
   }
 
   private transformComponentBundle(file: Vinyl) {
@@ -152,6 +176,7 @@ class AppPackageManifestTransform extends Transform {
     const setSDKVersion =
       (this.components.watch && this.hasJS) || this.components.companion;
     const { deviceApi, companionApi } = apiVersions(this.projectConfig);
+    this.populateTileData();
     const manifestJSON = JSON.stringify(
       {
         buildId: this.buildID,


### PR DESCRIPTION
 #### Summary of changes
 Add tiles data format to package.json
 Write tile data into the resulting manifest.json file.
 Tiles are available just for apps.

 Add unit test for new functionality

 #### Summary of testing
 Add tiles into package.json and make sure that the manifest is generated
 successfully. Tested both with mentioned buildTargets and with default
 buildTargets.

 Test error cases:
 * Duplicate UUIDS
 * Missing name
 * Missing UUIDS
 * appType != APP

Signed-off-by: Catalin Ghenea <gcatalin@google.com>