### PR TITLE
Change platform reference for tiles

### DIFF
--- a/src/ProjectConfiguration.test.ts
+++ b/src/ProjectConfiguration.test.ts
@@ -369,7 +369,9 @@ it('validationErrors() validates all fields', () => {
       },
     ],
   };
-  const diagnosticsTiles = config.validate(configFileTiles).diagnostics;
+  const diagnosticsTiles = config.validate(configFileTiles, {
+    hasNativeComponents: false,
+  }).diagnostics;
   expect(diagnosticsTiles).toEqual([
     expect.objectContaining({
       category: DiagnosticCategory.Error,
@@ -390,6 +392,11 @@ it('validationErrors() validates all fields', () => {
     expect.objectContaining({
       category: DiagnosticCategory.Error,
       messageText: 'Tile name must be specified',
+    }),
+    expect.objectContaining({
+      category: DiagnosticCategory.Warning,
+      messageText:
+        'Tiles available only for native components. Skipping tile configuration!',
     }),
   ]);
 });
@@ -448,24 +455,18 @@ describe('validateBuildTarget()', () => {
 
 describe('validateTileBuildTarget()', () => {
   it('allows empty list for tiles', () => {
-    const configFile: any = {
-      buildTargets: ['known_device'],
-    };
     expect(
       config.validateTileBuildTarget(
         {
           name: '__random__',
           uuid: '__random__',
         },
-        configFile,
+        {} as config.AppProjectConfiguration,
       ).diagnostics,
     ).toHaveLength(0);
   });
 
   it('validates values for tiles', () => {
-    const configFile: any = {
-      buildTargets: ['known_device'],
-    };
     expect(
       config.validateTileBuildTarget(
         {
@@ -473,7 +474,7 @@ describe('validateTileBuildTarget()', () => {
           uuid: '__random__',
           buildTargets: ['_invalid_device_'],
         },
-        configFile,
+        {} as config.AppProjectConfiguration,
       ).diagnostics[0],
     ).toEqual(
       expect.objectContaining({

--- a/src/ProjectConfiguration.ts
+++ b/src/ProjectConfiguration.ts
@@ -651,12 +651,12 @@ export function validateTileComponentAppType(config: ProjectConfiguration) {
 
 export function validateTileBuildTarget(
   tile: Tile,
-  { buildTargets }: AppProjectConfiguration,
+  config: AppProjectConfiguration,
 ) {
   if (tile.buildTargets !== undefined) {
     return constrainedSetDiagnostics({
       actualValues: tile.buildTargets,
-      knownValues: buildTargets,
+      knownValues: knownBuildTargets,
       valueTypeNoun: 'tile build targets',
       notFoundIsFatal: true,
     });
@@ -681,6 +681,16 @@ export function validateTileUUID(tile: Tile, config: AppProjectConfiguration) {
     diagnostic.pushFatalError("Can't have duplicate UUIDs between tiles");
   }
 
+  return diagnostic;
+}
+
+export function validateTileNativeComponent(hasNativeComponents: boolean) {
+  const diagnostic = new DiagnosticList();
+  if (!hasNativeComponents) {
+    diagnostic.pushWarning(
+      'Tiles available only for native components. Skipping tile configuration!',
+    );
+  }
   return diagnostic;
 }
 
@@ -730,6 +740,7 @@ export function validate(
         );
       },
     );
+    diagnostics.extend(validateTileNativeComponent(hasNativeComponents));
   }
 
   return diagnostics;

--- a/src/__snapshots__/appPackageManifest.test.ts.snap
+++ b/src/__snapshots__/appPackageManifest.test.ts.snap
@@ -241,42 +241,56 @@ Object {
         "platform": Array [
           "128.1.1+",
         ],
-        "supports": Object {
-          "screenSize": Object {
-            "h": 336,
-            "w": 336,
-          },
-        },
       },
       "vulcan": Object {
         "filename": "device-vulcan.zip",
         "platform": Array [
           "128.1.1+",
         ],
-        "supports": Object {
-          "screenSize": Object {
-            "h": 336,
-            "w": 336,
-          },
-        },
       },
     },
   },
   "manifestVersion": 6,
   "requestedPermissions": Array [],
-  "sdkVersion": Object {
-    "deviceApi": "8.1.0",
-  },
-  "sourceMaps": Object {
-    "device": Object {
-      "atlas": "sourceMaps/device/atlas/index.js.json",
-      "vulcan": "sourceMaps/device/vulcan/index.js.json",
-    },
-  },
+  "sourceMaps": Object {},
 }
 `;
 
 exports[`doesn't include tile data if app type is not APP 1`] = `
+Object {
+  "appId": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
+  "buildId": "0x0f75775f470c1585",
+  "components": Object {
+    "watch": Object {
+      "atlas": Object {
+        "filename": "device-atlas.zip",
+        "platform": Array [
+          "128.1.1+",
+        ],
+      },
+    },
+  },
+  "manifestVersion": 6,
+  "requestedPermissions": Array [],
+  "sourceMaps": Object {},
+}
+`;
+
+exports[`emits an error if a component bundle tag has a device type but invalid platform 1`] = `"Unknown bundle component tag: Invalid value \\"1.1.1+\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
+
+exports[`emits an error if a component bundle tag has a device type but missing family 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/family: string"`;
+
+exports[`emits an error if a component bundle tag has a device type but missing platform 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
+
+exports[`emits an error if a component bundle tag has an invalid type field 1`] = `"Unknown bundle component tag: Invalid value {\\"type\\":\\"__invalid__\\"} supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })"`;
+
+exports[`emits an error if both JS and native device components are present 1`] = `"Cannot bundle mixed native/JS device components"`;
+
+exports[`emits an error if multiple companion bundles are present for the same device family 1`] = `"Duplicate companion component bundles: bundle1.zip / bundle0.zip"`;
+
+exports[`emits an error if multiple device bundles are present for the same device family 1`] = `"Duplicate device/atlas component bundles: bundle1.zip / bundle0.zip"`;
+
+exports[`includes tiles just for native apps 1`] = `
 Object {
   "appId": "b4ae822e-eca9-4fcb-8747-217f2a1f53a1",
   "buildId": "0x0f75775f470c1585",
@@ -308,17 +322,3 @@ Object {
   },
 }
 `;
-
-exports[`emits an error if a component bundle tag has a device type but invalid platform 1`] = `"Unknown bundle component tag: Invalid value \\"1.1.1+\\" supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
-
-exports[`emits an error if a component bundle tag has a device type but missing family 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/family: string"`;
-
-exports[`emits an error if a component bundle tag has a device type but missing platform 1`] = `"Unknown bundle component tag: Invalid value undefined supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })/0: ({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>)/0: { type: \\"device\\", family: string, platform: Array<string> }/platform: Array<string>"`;
-
-exports[`emits an error if a component bundle tag has an invalid type field 1`] = `"Unknown bundle component tag: Invalid value {\\"type\\":\\"__invalid__\\"} supplied to : (({ type: \\"device\\", family: string, platform: Array<string> } & Partial<{ isNative: true }>) | { type: \\"companion\\" })"`;
-
-exports[`emits an error if both JS and native device components are present 1`] = `"Cannot bundle mixed native/JS device components"`;
-
-exports[`emits an error if multiple companion bundles are present for the same device family 1`] = `"Duplicate companion component bundles: bundle1.zip / bundle0.zip"`;
-
-exports[`emits an error if multiple device bundles are present for the same device family 1`] = `"Duplicate device/atlas component bundles: bundle1.zip / bundle0.zip"`;

--- a/src/appPackageManifest.test.ts
+++ b/src/appPackageManifest.test.ts
@@ -244,7 +244,12 @@ it('builds a package with tiles component', () => {
     {
       name: 'Tile2',
       uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a3',
-      buildTargets: ['atlas'], // Explictly specify buildTargets
+      buildTargets: ['atlas', '_unknown_device_'], // Explictly specify buildTargets
+    },
+    {
+      name: 'Unused Tile',
+      uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a4',
+      buildTargets: ['__invalid_device__'],
     },
   ];
 
@@ -255,7 +260,10 @@ it('builds a package with tiles component', () => {
     buildTargets: ['atlas', 'vulcan'],
   } as AppProjectConfiguration;
 
-  return expectValidPackageManifest({ projectConfig }).toMatchSnapshot();
+  return expectValidPackageManifest({
+    projectConfig,
+    nativeApp: true,
+  }).toMatchSnapshot();
 });
 
 it("doesn't include tile data if app type is not APP", () => {
@@ -277,5 +285,28 @@ it("doesn't include tile data if app type is not APP", () => {
     appType: AppType.CLOCKFACE,
   } as ClockProjectConfiguration;
 
-  return expectValidPackageManifest({ projectConfig }).toMatchSnapshot();
+  return expectValidPackageManifest({
+    projectConfig,
+    nativeApp: true,
+  }).toMatchSnapshot();
+});
+
+it('includes tiles just for native apps', () => {
+  const tiles: Tile[] = [
+    {
+      name: 'Tile1',
+      uuid: 'b4ae822e-eca9-4fcb-8747-217f2a1f53a2',
+    },
+  ];
+
+  const projectConfig = {
+    ...makeProjectConfig(),
+    tiles,
+    appType: AppType.APP,
+  } as AppProjectConfiguration;
+
+  return expectValidPackageManifest({
+    projectConfig,
+    nativeApp: false,
+  }).toMatchSnapshot();
 });

--- a/src/appPackageManifest.ts
+++ b/src/appPackageManifest.ts
@@ -88,15 +88,27 @@ class AppPackageManifestTransform extends Transform {
     if (this.projectConfig.appType === AppType.APP) {
       const appConfig = this.projectConfig;
 
-      if (appConfig.tiles !== undefined) {
+      if (appConfig.tiles !== undefined && this.hasNative) {
+        const watchComponents = Object.keys(this.components.watch ?? []);
+
         this.components.tiles = appConfig.tiles.map((tile) => ({
           name: tile.name,
           id: tile.uuid,
           platforms:
             tile.buildTargets !== undefined
-              ? tile.buildTargets
-              : appConfig.buildTargets,
+              ? tile.buildTargets.filter((target) =>
+                  watchComponents.includes(target),
+                )
+              : watchComponents,
         }));
+
+        // Remove tiles with 0 platforms
+        this.components.tiles = this.components.tiles.filter(
+          (tile) => tile.platforms.length > 0,
+        );
+        if (this.components.tiles.length === 0) {
+          this.components.tiles = undefined;
+        }
       }
     }
   }


### PR DESCRIPTION
 #### Summary of changes
 * Check tile build targets against all known devices
   not just the ones present in the global build targets list
 * Include tile for platforms that have an associated watch component
 * Allow tiles just for native bundles
 * Add unit tests for new functionality

 #### Summary of testing
 Bundles are generated correctly.
 * All tiles present in bundle have an associated watch component
 * Tiles that don't have an associated watch component
   are not included in the final bundle
 * A warning is issued if we try to build tiles without native components

Signed-off-by: Catalin Ghenea <gcatalin@google.com>