### PR TITLE
Skip capabilities check for native components

### DIFF
--- a/src/capabilities.test.ts
+++ b/src/capabilities.test.ts
@@ -15,5 +15,9 @@ describe('SupportedDeviceCapabilities', () => {
         }),
       );
     });
+
+    it('returns undefined for an unknown device', () => {
+      expect(SupportedDeviceCapabilities.create('unknown')).toBeUndefined();
+    });
   });
 });

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -31,13 +31,15 @@ export namespace SupportedDeviceCapabilities {
   export function create(
     targetDevice: string,
   ): SupportedDeviceCapabilities | undefined {
-    const { screenSize } = buildTargets[targetDevice].specs;
+    const specs = buildTargets[targetDevice]?.specs;
 
-    return {
-      [DeviceCapability.SCREEN_SIZE]: {
-        w: screenSize.width,
-        h: screenSize.height,
-      },
-    };
+    return specs
+      ? {
+          [DeviceCapability.SCREEN_SIZE]: {
+            w: specs.screenSize.width,
+            h: specs.screenSize.height,
+          },
+        }
+      : undefined;
   }
 }


### PR DESCRIPTION
 #### Summary of changes
 When building for native components
 skip the capabilities check as they are available
 just for JS targets

 #### Summary of testing
 Removed Vulcan from buildTargets and built with a
 native component for the Vulcan device.
 The build is successful

 Added unit test for new functionality

Signed-off-by: Catalin Ghenea <gcatalin@google.com>